### PR TITLE
Add example rebuild operations to mctl

### DIFF
--- a/csi/src/mayastor_svc.rs
+++ b/csi/src/mayastor_svc.rs
@@ -333,4 +333,34 @@ impl service::mayastor_server::Mayastor for MayastorService {
             .await?;
         Ok(Response::new(Null {}))
     }
+
+    async fn get_rebuild_state(
+        &self,
+        request: Request<RebuildStateRequest>,
+    ) -> Result<Response<RebuildStateReply>, Status> {
+        let msg = request.into_inner();
+        trace!("{:?}", msg);
+        let r = jsonrpc::call::<_, RebuildStateReply>(
+            &self.socket,
+            "get_rebuild_state",
+            Some(msg),
+        )
+        .await?;
+        Ok(Response::new(r))
+    }
+
+    async fn get_rebuild_progress(
+        &self,
+        request: Request<RebuildProgressRequest>,
+    ) -> Result<Response<RebuildProgressReply>, Status> {
+        let msg = request.into_inner();
+        trace!("{:?}", msg);
+        let r = jsonrpc::call::<_, RebuildProgressReply>(
+            &self.socket,
+            "get_rebuild_progress",
+            Some(msg),
+        )
+        .await?;
+        Ok(Response::new(r))
+    }
 }

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -15,10 +15,18 @@ use serde::Serialize;
 use snafu::{ResultExt, Snafu};
 
 use spdk_sys::{
-    spdk_bdev, spdk_bdev_desc, spdk_bdev_io, spdk_bdev_io_get_buf,
-    spdk_bdev_readv_blocks, spdk_bdev_register, spdk_bdev_unmap_blocks,
-    spdk_bdev_unregister, spdk_bdev_writev_blocks, spdk_io_channel,
-    spdk_io_device_register, spdk_io_device_unregister,
+    spdk_bdev,
+    spdk_bdev_desc,
+    spdk_bdev_io,
+    spdk_bdev_io_get_buf,
+    spdk_bdev_readv_blocks,
+    spdk_bdev_register,
+    spdk_bdev_unmap_blocks,
+    spdk_bdev_unregister,
+    spdk_bdev_writev_blocks,
+    spdk_io_channel,
+    spdk_io_device_register,
+    spdk_io_device_unregister,
 };
 
 use rpc::mayastor::{RebuildProgressReply, RebuildStateReply};
@@ -118,17 +126,39 @@ pub enum Error {
 impl RpcErrorCode for Error {
     fn rpc_error_code(&self) -> Code {
         match self {
-            Error::NexusNotFound { .. } => Code::NotFound,
-            Error::InvalidUuid { .. } => Code::InvalidParams,
-            Error::InvalidKey { .. } => Code::InvalidParams,
-            Error::AlreadyShared { .. } => Code::InvalidParams,
-            Error::NotShared { .. } => Code::InvalidParams,
-            Error::CreateChild { .. } => Code::InvalidParams,
-            Error::MixedBlockSizes { .. } => Code::InvalidParams,
-            Error::ChildGeometry { .. } => Code::InvalidParams,
-            Error::OpenChild { .. } => Code::InvalidParams,
-            Error::DestroyLastChild { .. } => Code::InvalidParams,
-            Error::ChildNotFound { .. } => Code::NotFound,
+            Error::NexusNotFound {
+                ..
+            } => Code::NotFound,
+            Error::InvalidUuid {
+                ..
+            } => Code::InvalidParams,
+            Error::InvalidKey {
+                ..
+            } => Code::InvalidParams,
+            Error::AlreadyShared {
+                ..
+            } => Code::InvalidParams,
+            Error::NotShared {
+                ..
+            } => Code::InvalidParams,
+            Error::CreateChild {
+                ..
+            } => Code::InvalidParams,
+            Error::MixedBlockSizes {
+                ..
+            } => Code::InvalidParams,
+            Error::ChildGeometry {
+                ..
+            } => Code::InvalidParams,
+            Error::OpenChild {
+                ..
+            } => Code::InvalidParams,
+            Error::DestroyLastChild {
+                ..
+            } => Code::InvalidParams,
+            Error::ChildNotFound {
+                ..
+            } => Code::NotFound,
             _ => Code::InternalError,
         }
     }

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -15,19 +15,13 @@ use serde::Serialize;
 use snafu::{ResultExt, Snafu};
 
 use spdk_sys::{
-    spdk_bdev,
-    spdk_bdev_desc,
-    spdk_bdev_io,
-    spdk_bdev_io_get_buf,
-    spdk_bdev_readv_blocks,
-    spdk_bdev_register,
-    spdk_bdev_unmap_blocks,
-    spdk_bdev_unregister,
-    spdk_bdev_writev_blocks,
-    spdk_io_channel,
-    spdk_io_device_register,
-    spdk_io_device_unregister,
+    spdk_bdev, spdk_bdev_desc, spdk_bdev_io, spdk_bdev_io_get_buf,
+    spdk_bdev_readv_blocks, spdk_bdev_register, spdk_bdev_unmap_blocks,
+    spdk_bdev_unregister, spdk_bdev_writev_blocks, spdk_io_channel,
+    spdk_io_device_register, spdk_io_device_unregister,
 };
+
+use rpc::mayastor::{RebuildProgressReply, RebuildStateReply};
 
 use crate::{
     bdev::{
@@ -124,39 +118,17 @@ pub enum Error {
 impl RpcErrorCode for Error {
     fn rpc_error_code(&self) -> Code {
         match self {
-            Error::NexusNotFound {
-                ..
-            } => Code::NotFound,
-            Error::InvalidUuid {
-                ..
-            } => Code::InvalidParams,
-            Error::InvalidKey {
-                ..
-            } => Code::InvalidParams,
-            Error::AlreadyShared {
-                ..
-            } => Code::InvalidParams,
-            Error::NotShared {
-                ..
-            } => Code::InvalidParams,
-            Error::CreateChild {
-                ..
-            } => Code::InvalidParams,
-            Error::MixedBlockSizes {
-                ..
-            } => Code::InvalidParams,
-            Error::ChildGeometry {
-                ..
-            } => Code::InvalidParams,
-            Error::OpenChild {
-                ..
-            } => Code::InvalidParams,
-            Error::DestroyLastChild {
-                ..
-            } => Code::InvalidParams,
-            Error::ChildNotFound {
-                ..
-            } => Code::NotFound,
+            Error::NexusNotFound { .. } => Code::NotFound,
+            Error::InvalidUuid { .. } => Code::InvalidParams,
+            Error::InvalidKey { .. } => Code::InvalidParams,
+            Error::AlreadyShared { .. } => Code::InvalidParams,
+            Error::NotShared { .. } => Code::InvalidParams,
+            Error::CreateChild { .. } => Code::InvalidParams,
+            Error::MixedBlockSizes { .. } => Code::InvalidParams,
+            Error::ChildGeometry { .. } => Code::InvalidParams,
+            Error::OpenChild { .. } => Code::InvalidParams,
+            Error::DestroyLastChild { .. } => Code::InvalidParams,
+            Error::ChildNotFound { .. } => Code::NotFound,
             _ => Code::InternalError,
         }
     }
@@ -694,6 +666,22 @@ impl Nexus {
     /// returns the current status of the nexus
     pub fn status(&self) -> NexusState {
         self.state
+    }
+
+    pub async fn get_rebuild_state(&self) -> Result<RebuildStateReply, Error> {
+        // TODO: add real implementation
+        Ok(RebuildStateReply {
+            state: "Not implemented".to_string(),
+        })
+    }
+
+    pub async fn get_rebuild_progress(
+        &self,
+    ) -> Result<RebuildProgressReply, Error> {
+        // TODO: add real implementation
+        Ok(RebuildProgressReply {
+            progress: "Not implemented".to_string(),
+        })
     }
 }
 

--- a/mayastor/src/bdev/nexus/nexus_rpc.rs
+++ b/mayastor/src/bdev/nexus/nexus_rpc.rs
@@ -2,10 +2,19 @@ use futures::{future, FutureExt};
 use uuid::Uuid;
 
 use rpc::mayastor::{
-    AddChildNexusRequest, Child, ChildNexusRequest, CreateNexusRequest,
-    DestroyNexusRequest, ListNexusReply, Nexus as RpcNexus, PublishNexusReply,
-    PublishNexusRequest, RebuildProgressRequest, RebuildStateRequest,
-    RemoveChildNexusRequest, UnpublishNexusRequest,
+    AddChildNexusRequest,
+    Child,
+    ChildNexusRequest,
+    CreateNexusRequest,
+    DestroyNexusRequest,
+    ListNexusReply,
+    Nexus as RpcNexus,
+    PublishNexusReply,
+    PublishNexusRequest,
+    RebuildProgressRequest,
+    RebuildStateRequest,
+    RemoveChildNexusRequest,
+    UnpublishNexusRequest,
 };
 
 use crate::{
@@ -48,7 +57,7 @@ fn nexus_lookup(uuid: &str) -> Result<&mut Nexus, Error> {
 /// jsonrpc api, we return the whole name without modifications as it is.
 fn name_to_uuid(name: &str) -> &str {
     if name.starts_with("nexus-") {
-        &name[6..]
+        &name[6 ..]
     } else {
         name
     }
@@ -124,10 +133,9 @@ pub(crate) fn register_rpc_methods() {
                 if args.key == "" { None } else { Some(args.key) };
 
             let nexus = nexus_lookup(&args.uuid)?;
-            nexus
-                .share(key)
-                .await
-                .map(|device_path| PublishNexusReply { device_path })
+            nexus.share(key).await.map(|device_path| PublishNexusReply {
+                device_path,
+            })
         };
         fut.boxed_local()
     });

--- a/rpc/proto/mayastor.proto
+++ b/rpc/proto/mayastor.proto
@@ -191,3 +191,19 @@ message ChildNexusRequest {
   string uri =2;
   ChildAction action = 3;
 }
+
+message RebuildStateRequest {
+  string uuid = 1;  // uuid of the nexus
+}
+
+message RebuildStateReply {
+  string state = 1; // current rebuild state (i.e. ready/running/completed etc.)
+}
+
+message RebuildProgressRequest {
+  string uuid = 1;  // uuid of the nexus
+}
+
+message RebuildProgressReply {
+  string progress = 1;  // progress percentage
+}

--- a/rpc/proto/mayastor_service.proto
+++ b/rpc/proto/mayastor_service.proto
@@ -45,4 +45,8 @@ service Mayastor {
 
 	// Nexus child operations
 	rpc ChildOperation(mayastor.ChildNexusRequest) returns (mayastor.Null) {}
+
+	// Rebuild operations
+	rpc GetRebuildState (mayastor.RebuildStateRequest) returns (mayastor.RebuildStateReply) {}
+	rpc GetRebuildProgress (mayastor.RebuildProgressRequest) returns (mayastor.RebuildProgressReply) {}
 }


### PR DESCRIPTION
Add unimplemented mctl operations for getting rebuild state and rebuild progress.
This will serve as a reference for adding future rebuild operations to mctl.