### PR TITLE
cargo fmt changes are not being detected by the linter (#132)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,9 @@ lint:
     - nix-shell --run 'prettier --version'
     - nix-shell --run 'prettier --config .prettierrc --check csi/moac/*.js mayastor-test/*.js'
     - nix-shell --run 'jshint --config .jshintrc csi/moac/*.js mayastor-test/*.js'
-    - nix-shell --run 'cargo fmt --all'
+    # We don't want to perform this check for the submodules as it should be done in their respective repos
+    - echo 'set -e; for d in */Cargo.toml; do dir=$(dirname "$d"); if [ ! -f "$dir"/.git ]; then echo "cargo fmt -p "$dir" -- --check"; cargo fmt -p "$dir" -- --check; fi; done' > fmt.sh
+    - nix-shell --run 'sh fmt.sh'
     - nix-shell --run 'cargo clippy --all --all-targets -- -D warnings'
   only:
     - external_pull_requests

--- a/mayastor/src/bdev/mod.rs
+++ b/mayastor/src/bdev/mod.rs
@@ -7,8 +7,8 @@ pub use nexus::{
     nexus_label::{GPTHeader, GptEntry},
 };
 pub use nvmf_dev::{NvmeCtlAttachReq, NvmfParseError};
-pub use uring_dev::{UringBdev, UringParseError};
 use spdk_sys::{spdk_conf_section, spdk_conf_section_get_nmval};
+pub use uring_dev::{UringBdev, UringParseError};
 
 /// Allocate C string and return pointer to it.
 /// NOTE: you must explicitly free it, otherwise the memory is leaked!

--- a/mayastor/src/bdev/uring_dev.rs
+++ b/mayastor/src/bdev/uring_dev.rs
@@ -67,7 +67,11 @@ impl UringBdev {
         if let Some(bdev) = Bdev::lookup_by_name(&self.name) {
             let (s, r) = oneshot::channel::<ErrnoResult<()>>();
             unsafe {
-                delete_uring_bdev(bdev.as_ptr(), Some(done_errno_cb), cb_arg(s));
+                delete_uring_bdev(
+                    bdev.as_ptr(),
+                    Some(done_errno_cb),
+                    cb_arg(s),
+                );
             }
             r.await.expect("Cancellation is not supported").context(
                 nexus_uri::DestroyBdev {

--- a/mayastor/src/nexus_uri.rs
+++ b/mayastor/src/nexus_uri.rs
@@ -37,7 +37,10 @@ pub enum BdevCreateDestroy {
     #[snafu(display("Failed to parse nvmf URI \"{}\"", uri))]
     ParseNvmfUri { source: NvmfParseError, uri: String },
     #[snafu(display("Failed to parse uring URI \"{}\"", uri))]
-    ParseUringUri { source: UringParseError, uri: String },
+    ParseUringUri {
+        source: UringParseError,
+        uri: String,
+    },
     // bdev create/destroy errors
     #[snafu(display("bdev {} already exists", name))]
     BdevExists { name: String },

--- a/mayastor/tests/core.rs
+++ b/mayastor/tests/core.rs
@@ -38,7 +38,8 @@ fn fs_supports_direct_io() -> bool {
         .read(true)
         .write(true)
         .custom_flags(libc::O_DIRECT)
-        .open(DISKNAME3) {
+        .open(DISKNAME3)
+    {
         Ok(_f) => true,
         Err(e) => {
             assert_eq!(e.kind(), ErrorKind::InvalidInput);
@@ -77,9 +78,9 @@ fn get_mount_filesystem() -> Option<String> {
 
         path = match path.parent() {
             None => return None,
-            Some(p) => p
+            Some(p) => p,
         }
-    };
+    }
 }
 
 fn fs_type_supported() -> bool {
@@ -88,15 +89,13 @@ fn fs_type_supported() -> bool {
             println!("Skipping uring bdev, unknown fs");
             false
         }
-        Some(d) => {
-            match d.as_str() {
-                "xfs" => true,
-                _ => {
-                    println!("Skipping uring bdev, fs: {}", d);
-                    false
-                }
+        Some(d) => match d.as_str() {
+            "xfs" => true,
+            _ => {
+                println!("Skipping uring bdev, fs: {}", d);
+                false
             }
-        }
+        },
     }
 }
 
@@ -117,17 +116,21 @@ fn kernel_supports_io_uring() -> bool {
 fn do_uring() -> bool {
     unsafe {
         INIT.call_once(|| {
-            DO_URING = fs_supports_direct_io() && fs_type_supported()
-                        && kernel_supports_io_uring();
+            DO_URING = fs_supports_direct_io()
+                && fs_type_supported()
+                && kernel_supports_io_uring();
         });
         DO_URING
     }
 }
 
-
 async fn create_nexus() {
     let ch = if do_uring() {
-        vec![BDEVNAME1.to_string(), BDEVNAME2.to_string(), BDEVNAME3.to_string()]
+        vec![
+            BDEVNAME1.to_string(),
+            BDEVNAME2.to_string(),
+            BDEVNAME3.to_string(),
+        ]
     } else {
         vec![BDEVNAME1.to_string(), BDEVNAME2.to_string()]
     };

--- a/mayastor/tests/nexus_rebuild.rs
+++ b/mayastor/tests/nexus_rebuild.rs
@@ -71,7 +71,7 @@ async fn rebuild_test_start() {
     std::thread::spawn(move || {
         select! {
             recv(rebuild_complete) -> state => info!("rebuild of child {} finished with state {:?}", BDEVNAME2, state),
-            recv(after(Duration::from_secs(2))) -> _ => panic!("timed out waiting for the rebuild to complete"),
+            recv(after(Duration::from_secs(5))) -> _ => panic!("timed out waiting for the rebuild to complete"),
         }
         s.send(())
     });


### PR DESCRIPTION
the changes are only applied during test and do not fail the PR so unformatted code can be checked in master...

currently the spdk-sys submodule has ill formatted code... we avoid running the format check against submodules as that should be handled in the respective repos