### PR TITLE
rebuild: Move rebuild task list from the nexus into a global scope

### DIFF
--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -122,8 +122,8 @@ pub enum Error {
     ChildNotFound { child: String, name: String },
     #[snafu(display("Child {} of nexus {} is not closed", child, name))]
     ChildNotClosed { child: String, name: String },
-    #[snafu(display("Open Child of nexus {} not found", name))]
-    OpenChildNotFound { name: String },
+    #[snafu(display("Suitable rebuild source for nexus {} not found", name))]
+    NoRebuildSource { name: String },
     #[snafu(display(
         "Failed to start rebuilding child {} of nexus {}",
         child,
@@ -141,7 +141,7 @@ pub enum Error {
     ))]
     RebuildTaskNotFound { child: String, name: String },
     #[snafu(display(
-        "Failed remove rebuild task {} of nexus {}",
+        "Failed to remove rebuild task {} of nexus {}",
         child,
         name,
     ))]

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -516,12 +516,12 @@ impl Nexus {
         if task.state == RebuildState::Completed {
             recovered_child.state = ChildState::Open;
 
-            // child can now be part of the IO path
-            self.reconfigure(DREvent::ChildOnline).await;
-
             // Actually we'd have to check if all other children are healthy
             // and if not maybe we can start the other rebuild's?
             self.set_state(NexusState::Online);
+
+            // child can now be part of the IO path
+            self.reconfigure(DREvent::ChildOnline).await;
         } else {
             error!(
                 "Rebuild task for child {} of nexus {} failed with state {:?}",

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -483,10 +483,10 @@ impl Nexus {
 
     /// Return rebuild task associated with the child name.
     /// Return error if no rebuild task associated with it.
-    fn get_rebuild_task<'b>(
+    fn get_rebuild_task<'a>(
         &mut self,
-        name: &'b str,
-    ) -> Result<&'b mut RebuildTask, Error> {
+        name: &'a str,
+    ) -> Result<&'a mut RebuildTask, Error> {
         if let Ok(task) = RebuildTask::lookup(name) {
             if task.nexus == self.name {
                 return Ok(task);

--- a/mayastor/src/bdev/nexus/nexus_rpc.rs
+++ b/mayastor/src/bdev/nexus/nexus_rpc.rs
@@ -25,6 +25,7 @@ use crate::{
         nexus_bdev::{nexus_create, Error, Nexus},
     },
     jsonrpc::jsonrpc_register,
+    rebuild::RebuildTask,
 };
 
 /// Convert the UUID to a nexus name in the form of "nexus-{uuid}".
@@ -84,7 +85,7 @@ pub(crate) fn register_rpc_methods() {
                         })
                         .collect::<Vec<_>>(),
                     device_path: nexus.get_share_path().unwrap_or_default(),
-                    rebuilds: nexus.rebuilds.len() as u64,
+                    rebuilds: RebuildTask::count() as u64,
                 })
                 .collect::<Vec<_>>(),
         })

--- a/mayastor/src/rebuild.rs
+++ b/mayastor/src/rebuild.rs
@@ -83,14 +83,14 @@ pub trait RebuildActions {
 impl RebuildTask {
     /// Returns a newly created RebuildTask which is already stored in the
     /// rebuild list
-    pub fn create<'b>(
+    pub fn create<'a>(
         nexus: &str,
         source: &str,
-        destination: &'b str,
+        destination: &'a str,
         start: u64,
         end: u64,
         complete_fn: fn(String, String) -> (),
-    ) -> Result<&'b mut Self, RebuildError> {
+    ) -> Result<&'a mut Self, RebuildError> {
         Self::new(nexus, source, destination, start, end, complete_fn)?
             .store()?;
 


### PR DESCRIPTION
This makes it easier to interact with the rebuild task list using its destination alone as a key
Also tidy up some of the doc comments and reorder the code a bit