### PR TITLE
rebuild: add progress and map child states

### DIFF
--- a/mayastor-test/test_nexus.js
+++ b/mayastor-test/test_nexus.js
@@ -305,25 +305,25 @@ describe('nexus', function () {
       assert.equal(nexus.state, 'online');
       assert.lengthOf(nexus.children, expectedChildren);
       assert.equal(nexus.children[0].uri, 'bdev:///Malloc0');
-      assert.equal(nexus.children[0].state, 'open');
+      assert.equal(nexus.children[0].state, 'online');
       assert.equal(nexus.children[1].uri, `aio:///${aioFile}?blk_size=4096`);
-      assert.equal(nexus.children[1].state, 'open');
+      assert.equal(nexus.children[1].state, 'online');
       assert.equal(
         nexus.children[2].uri,
         `iscsi://${externIp}:3261/iqn.2019-05.io.openebs:disk1`
       );
-      assert.equal(nexus.children[2].state, 'open');
+      assert.equal(nexus.children[2].state, 'online');
       assert.equal(
         nexus.children[3].uri,
         'nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:disk2'
       );
-      assert.equal(nexus.children[3].state, 'open');
+      assert.equal(nexus.children[3].state, 'online');
       if (doUring()) {
         assert.equal(
           nexus.children[4].uri,
           `uring:///${uringFile}?blk_size=4096`
         );
-        assert.equal(nexus.children[4].state, 'open');
+        assert.equal(nexus.children[4].state, 'online');
       }
       done();
     });

--- a/mayastor-test/test_rebuild.js
+++ b/mayastor-test/test_rebuild.js
@@ -254,11 +254,11 @@ describe('rebuild tests', function () {
     });
 
     it('check source state', async () => {
-      await checkState(ObjectType.SOURCE_CHILD, 'open');
+      await checkState(ObjectType.SOURCE_CHILD, 'online');
     });
 
     it('check destination state', async () => {
-      await checkState(ObjectType.DESTINATION_CHILD, 'faulted');
+      await checkState(ObjectType.DESTINATION_CHILD, 'rebuilding');
     });
 
     it('check rebuild state', async () => {
@@ -288,7 +288,7 @@ describe('rebuild tests', function () {
     });
 
     it('check source state', async () => {
-      await checkState(ObjectType.SOURCE_CHILD, 'open');
+      await checkState(ObjectType.SOURCE_CHILD, 'online');
     });
 
     it('check destination state', async () => {
@@ -335,11 +335,11 @@ describe('rebuild tests', function () {
     });
 
     it('check source state', async () => {
-      await checkState(ObjectType.SOURCE_CHILD, 'open');
+      await checkState(ObjectType.SOURCE_CHILD, 'online');
     });
 
     it('check destination state', async () => {
-      await checkState(ObjectType.DESTINATION_CHILD, 'faulted');
+      await checkState(ObjectType.DESTINATION_CHILD, 'rebuilding');
     });
 
     it('check rebuild state', async () => {
@@ -371,11 +371,11 @@ describe('rebuild tests', function () {
     });
 
     it('check source state', async () => {
-      await checkState(ObjectType.SOURCE_CHILD, 'open');
+      await checkState(ObjectType.SOURCE_CHILD, 'online');
     });
 
     it('check destination state', async () => {
-      await checkState(ObjectType.DESTINATION_CHILD, 'faulted');
+      await checkState(ObjectType.DESTINATION_CHILD, 'rebuilding');
     });
 
     it('check rebuild state', async () => {
@@ -404,11 +404,11 @@ describe('rebuild tests', function () {
     });
 
     it('check source state', async () => {
-      await checkState(ObjectType.SOURCE_CHILD, 'open');
+      await checkState(ObjectType.SOURCE_CHILD, 'online');
     });
 
     it('check destination state', async () => {
-      await checkState(ObjectType.DESTINATION_CHILD, 'faulted');
+      await checkState(ObjectType.DESTINATION_CHILD, 'rebuilding');
     });
 
     it('check rebuild state', async () => {
@@ -436,11 +436,11 @@ describe('rebuild tests', function () {
     });
 
     it('check source state', async () => {
-      await checkState(ObjectType.SOURCE_CHILD, 'open');
+      await checkState(ObjectType.SOURCE_CHILD, 'online');
     });
 
     it('check destination state', async () => {
-      await checkState(ObjectType.DESTINATION_CHILD, 'closed');
+      await checkState(ObjectType.DESTINATION_CHILD, 'faulted');
     });
 
     it('check number of rebuilds', async () => {

--- a/mayastor-test/test_rebuild.js
+++ b/mayastor-test/test_rebuild.js
@@ -258,7 +258,7 @@ describe('rebuild tests', function () {
     });
 
     it('check destination state', async () => {
-      await checkState(ObjectType.DESTINATION_CHILD, 'rebuilding');
+      await checkState(ObjectType.DESTINATION_CHILD, 'degraded');
     });
 
     it('check rebuild state', async () => {
@@ -292,7 +292,7 @@ describe('rebuild tests', function () {
     });
 
     it('check destination state', async () => {
-      await checkState(ObjectType.DESTINATION_CHILD, 'faulted');
+      await checkState(ObjectType.DESTINATION_CHILD, 'degraded');
     });
 
     it('check rebuild state', async (done) => {
@@ -339,7 +339,7 @@ describe('rebuild tests', function () {
     });
 
     it('check destination state', async () => {
-      await checkState(ObjectType.DESTINATION_CHILD, 'rebuilding');
+      await checkState(ObjectType.DESTINATION_CHILD, 'degraded');
     });
 
     it('check rebuild state', async () => {
@@ -375,7 +375,7 @@ describe('rebuild tests', function () {
     });
 
     it('check destination state', async () => {
-      await checkState(ObjectType.DESTINATION_CHILD, 'rebuilding');
+      await checkState(ObjectType.DESTINATION_CHILD, 'degraded');
     });
 
     it('check rebuild state', async () => {
@@ -408,7 +408,7 @@ describe('rebuild tests', function () {
     });
 
     it('check destination state', async () => {
-      await checkState(ObjectType.DESTINATION_CHILD, 'rebuilding');
+      await checkState(ObjectType.DESTINATION_CHILD, 'degraded');
     });
 
     it('check rebuild state', async () => {

--- a/mayastor/src/bdev/mod.rs
+++ b/mayastor/src/bdev/mod.rs
@@ -3,7 +3,7 @@ use std::ffi::CStr;
 pub use aio_dev::{AioBdev, AioParseError};
 pub use iscsi_dev::{IscsiBdev, IscsiParseError};
 pub use nexus::{
-    nexus_bdev::{nexus_create, nexus_lookup, Nexus, NexusState},
+    nexus_bdev::{nexus_create, nexus_lookup, Nexus, NexusStatus},
     nexus_label::{GPTHeader, GptEntry},
 };
 pub use nvmf_dev::{NvmeCtlAttachReq, NvmfParseError};

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -37,7 +37,7 @@ use crate::{
         nexus::{
             instances,
             nexus_channel::{DREvent, NexusChannel, NexusChannelInner},
-            nexus_child::{ChildError, ChildState, NexusChild},
+            nexus_child::{ChildError, ChildState, ChildStatus, NexusChild},
             nexus_io::{io_status, Bio},
             nexus_iscsi::{NexusIscsiError, NexusIscsiTarget},
             nexus_label::LabelError,
@@ -172,12 +172,12 @@ pub enum Error {
     #[snafu(display("Failed to destroy nexus {}", name))]
     NexusDestroy { name: String },
     #[snafu(display(
-        "Child {} of nexus {} is not faulted but {}",
+        "Child {} of nexus {} is not degraded but {}",
         child,
         name,
         state
     ))]
-    ChildNotFaulted {
+    ChildNotDegraded {
         child: String,
         name: String,
         state: String,
@@ -301,7 +301,7 @@ pub struct Nexus {
     /// raw pointer to bdev (to destruct it later using Box::from_raw())
     bdev_raw: *mut spdk_bdev,
     /// represents the current state of the Nexus
-    pub(crate) state: NexusState,
+    pub(super) state: NexusState,
     /// Dynamic Reconfigure event
     pub dr_complete_notify: Option<oneshot::Sender<i32>>,
     /// the offset in num blocks where the data partition starts
@@ -317,27 +317,43 @@ unsafe impl core::marker::Sync for Nexus {}
 unsafe impl core::marker::Send for Nexus {}
 
 #[derive(Debug, Serialize, Clone, Copy, PartialEq, PartialOrd)]
+pub enum NexusStatus {
+    /// The nexus cannot perform any IO operation
+    Faulted,
+    /// Degraded, one or more child is missing but IO can still flow
+    Degraded,
+    /// Online
+    Online,
+}
+
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, PartialOrd)]
 pub enum NexusState {
     /// nexus created but no children attached
     Init,
     /// closed
     Closed,
-    /// Online
-    Online,
-    /// The nexus cannot perform any IO operation
-    Faulted,
-    /// Degraded, one or more child is missing but IO can still flow
-    Degraded,
+    /// open
+    Open,
 }
 
 impl ToString for NexusState {
     fn to_string(&self) -> String {
         match *self {
             NexusState::Init => "init",
-            NexusState::Online => "online",
-            NexusState::Faulted => "faulted",
-            NexusState::Degraded => "degraded",
             NexusState::Closed => "closed",
+            NexusState::Open => "open",
+        }
+        .parse()
+        .unwrap()
+    }
+}
+
+impl ToString for NexusStatus {
+    fn to_string(&self) -> String {
+        match *self {
+            NexusStatus::Degraded => "degraded",
+            NexusStatus::Online => "online",
+            NexusStatus::Faulted => "faulted",
         }
         .parse()
         .unwrap()
@@ -472,8 +488,7 @@ impl Nexus {
         self.children
             .iter_mut()
             .map(|c| {
-                if c.state == ChildState::Open || c.state == ChildState::Faulted
-                {
+                if c.state == ChildState::Open {
                     c.close();
                 }
             })
@@ -562,7 +577,7 @@ impl Nexus {
 
         match errno_result_from_i32((), errno) {
             Ok(_) => {
-                self.set_state(NexusState::Online);
+                self.set_state(NexusState::Open);
                 Ok(())
             }
             Err(err) => {
@@ -570,7 +585,7 @@ impl Nexus {
                     spdk_io_device_unregister(self.as_ptr(), None);
                 }
                 self.children.iter_mut().map(|c| c.close()).for_each(drop);
-                self.set_state(NexusState::Faulted);
+                self.set_state(NexusState::Closed);
                 Err(err).context(RegisterNexus {
                     name: self.name.clone(),
                 })
@@ -778,8 +793,28 @@ impl Nexus {
     }
 
     /// returns the current status of the nexus
-    pub fn status(&self) -> NexusState {
-        self.state
+    pub fn status(&self) -> NexusStatus {
+        match self.state {
+            NexusState::Init => NexusStatus::Degraded,
+            NexusState::Closed => NexusStatus::Faulted,
+            NexusState::Open => {
+                if self
+                    .children
+                    .iter()
+                    .all(|c| c.status() == ChildStatus::Online)
+                {
+                    NexusStatus::Online
+                } else if self
+                    .children
+                    .iter()
+                    .any(|c| c.status() == ChildStatus::Online)
+                {
+                    NexusStatus::Degraded
+                } else {
+                    NexusStatus::Faulted
+                }
+            }
+        }
     }
 }
 

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -33,6 +33,7 @@ use crate::{
             Error,
             Nexus,
             NexusState,
+            NexusStatus,
             OpenChild,
         },
         nexus_channel::DREvent,
@@ -91,7 +92,7 @@ impl Nexus {
     ///
     /// The child may require a rebuild first, so the nexus will
     /// transition to degraded mode when the addition has been successful.
-    pub async fn add_child(&mut self, uri: &str) -> Result<NexusState, Error> {
+    pub async fn add_child(&mut self, uri: &str) -> Result<NexusStatus, Error> {
         let name = bdev_create(&uri).await.context(CreateChild {
             name: self.name.clone(),
         })?;
@@ -139,20 +140,19 @@ impl Nexus {
                 // completed the device can transition to online
                 info!("{}: child opened successfully {}", self.name, name);
 
-                // mark faulted so that it can never take part in the IO path of
-                // the nexus until brought online.
-                child.state = ChildState::Faulted;
+                // it can never take part in the IO path
+                // of the nexus until it's rebuilt from a healthy child.
+                child.out_of_sync(true);
 
                 self.children.push(child);
                 self.child_count += 1;
-                self.set_state(NexusState::Degraded);
 
                 if let Err(e) = self.sync_labels().await {
                     error!("Failed to sync labels {:?}", e);
                     // todo: how to signal this?
                 }
 
-                Ok(self.state)
+                Ok(self.status())
             }
             Err(e) => {
                 if let Err(err) = bdev_destroy(uri).await {
@@ -202,7 +202,7 @@ impl Nexus {
     pub async fn offline_child(
         &mut self,
         name: &str,
-    ) -> Result<NexusState, Error> {
+    ) -> Result<NexusStatus, Error> {
         trace!("{}: Offline child request for {}", self.name, name);
 
         if let Some(child) = self.children.iter_mut().find(|c| c.name == name) {
@@ -216,7 +216,7 @@ impl Nexus {
 
         self.stop_rebuild(name).await?;
         self.reconfigure(DREvent::ChildOffline).await;
-        Ok(self.set_state(NexusState::Degraded))
+        Ok(self.status())
     }
 
     /// online a child and reconfigure the IO channels. The child is already
@@ -225,7 +225,7 @@ impl Nexus {
     pub async fn online_child(
         &mut self,
         name: &str,
-    ) -> Result<NexusState, Error> {
+    ) -> Result<NexusStatus, Error> {
         trace!("{} Online child request", self.name);
 
         if let Some(child) = self.children.iter_mut().find(|c| c.name == name) {
@@ -239,10 +239,9 @@ impl Nexus {
                     child: name.to_owned(),
                     name: self.name.clone(),
                 })?;
-                child.state = ChildState::Faulted;
-                let nexus_state = self.set_state(NexusState::Degraded);
+                child.out_of_sync(true);
                 self.start_rebuild_rpc(name).await?;
-                Ok(nexus_state)
+                Ok(self.status())
             }
         } else {
             Err(Error::ChildNotFound {

--- a/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
@@ -1,5 +1,5 @@
 use futures::channel::oneshot::Receiver;
-use rpc::mayastor::RebuildStateReply;
+use rpc::mayastor::{Child, RebuildProgressReply, RebuildStateReply};
 use snafu::ResultExt;
 
 use crate::{
@@ -15,7 +15,7 @@ use crate::{
             RemoveRebuildJob,
         },
         nexus_channel::DREvent,
-        nexus_child::ChildState,
+        nexus_child::{ChildState, NexusChild},
     },
     core::Reactors,
     rebuild::{ClientOperations, RebuildJob, RebuildState},
@@ -37,17 +37,25 @@ impl Nexus {
     ) -> Result<Receiver<RebuildState>, Error> {
         trace!("{}: start rebuild request for {}", self.name, name);
 
-        let src_child_name =
-            match self.children.iter().find(|c| c.state == ChildState::Open) {
-                Some(child) => Ok(child.name.clone()),
-                None => Err(Error::NoRebuildSource {
-                    name: self.name.clone(),
-                }),
-            }?;
+        let src_child_name = match self
+            .children
+            .iter()
+            .find(|c| c.state == ChildState::Open && c.name != name)
+        {
+            Some(child) => Ok(child.name.clone()),
+            None => Err(Error::NoRebuildSource {
+                name: self.name.clone(),
+            }),
+        }?;
 
         let dst_child = match self.children.iter_mut().find(|c| c.name == name)
         {
-            Some(c) => Ok(c),
+            Some(c) if c.state == ChildState::Faulted => Ok(c),
+            Some(_) => Err(Error::ChildNotFaulted {
+                child: name.to_owned(),
+                name: self.name.clone(),
+                state: self.state.to_string(),
+            }),
             None => Err(Error::ChildNotFound {
                 child: name.to_owned(),
                 name: self.name.clone(),
@@ -71,12 +79,27 @@ impl Nexus {
             name: self.name.clone(),
         })?;
 
-        dst_child.repairing = true;
-
         job.as_client().start().context(CreateRebuildError {
             child: name.to_owned(),
             name: self.name.clone(),
         })
+    }
+
+    /// Returns a `child` as an rpc Child type
+    pub fn to_rpc_child(&self, child: &NexusChild) -> Child {
+        let rj = self.get_rebuild_job(&child.name);
+
+        Child {
+            uri: child.name.clone(),
+            state: child.state.to_public(rj.is_ok()),
+            rebuild_progress: {
+                if let Ok(rj) = rj {
+                    rj.stats().progress
+                } else {
+                    Default::default()
+                }
+            },
+        }
     }
 
     /// Terminates a rebuild in the background
@@ -121,6 +144,18 @@ impl Nexus {
         let rj = self.get_rebuild_job(name)?;
         Ok(RebuildStateReply {
             state: rj.state().to_string(),
+        })
+    }
+
+    /// Returns the rebuild progress of child target `name`
+    pub fn get_rebuild_progress(
+        &self,
+        name: &str,
+    ) -> Result<RebuildProgressReply, Error> {
+        let rj = self.get_rebuild_job(name)?;
+
+        Ok(RebuildProgressReply {
+            progress: rj.as_client().stats().progress,
         })
     }
 
@@ -191,8 +226,6 @@ impl Nexus {
         job: &RebuildJob,
     ) -> Result<(), Error> {
         let recovered_child = self.get_child_by_name(&job.destination)?;
-
-        recovered_child.repairing = false;
 
         if job.state() == RebuildState::Completed {
             recovered_child.state = ChildState::Open;

--- a/mayastor/src/bdev/nexus/nexus_channel.rs
+++ b/mayastor/src/bdev/nexus/nexus_channel.rs
@@ -12,7 +12,7 @@ use spdk_sys::{
 };
 
 use crate::{
-    bdev::nexus::{nexus_child::ChildState, Nexus},
+    bdev::nexus::{nexus_child::ChildStatus, Nexus},
     core::BdevHandle,
 };
 
@@ -84,7 +84,7 @@ impl NexusChannelInner {
         nexus
             .children
             .iter_mut()
-            .filter(|c| c.state == ChildState::Open)
+            .filter(|c| c.status() == ChildStatus::Online)
             .map(|c| {
                 self.ch.push(
                     BdevHandle::try_from(c.get_descriptor().unwrap()).unwrap(),
@@ -122,7 +122,7 @@ impl NexusChannel {
         nexus
             .children
             .iter_mut()
-            .filter(|c| c.state == ChildState::Open)
+            .filter(|c| c.status() == ChildStatus::Online)
             .map(|c| {
                 channels.ch.push(
                     BdevHandle::try_from(c.get_descriptor().unwrap()).unwrap(),

--- a/mayastor/src/bdev/nexus/nexus_child.rs
+++ b/mayastor/src/bdev/nexus/nexus_child.rs
@@ -100,6 +100,35 @@ impl ToString for ChildState {
     }
 }
 
+/// Because the child states are kept separately from the rebuild states,
+/// when a rebuild is ongoing there are two states
+/// associated with the destination child:
+///     Rebuilding - from the rebuild job
+///     Faulted - from the child state
+/// The control plane doesn't require fine grained state information
+/// The required states are:
+///     Online
+///     Faulted
+///     Rebuilding
+/// so here we inject a "rebuilding" state into the ChildState
+impl ChildState {
+    /// Converts an internal mayastor child state into a simplified public state
+    /// visible outside of mayastor
+    pub(crate) fn to_public(self, rebuilding: bool) -> String {
+        match self {
+            ChildState::Init => "rebuilding",
+            ChildState::ConfigInvalid => "faulted",
+            ChildState::Open | ChildState::Faulted if rebuilding => {
+                "rebuilding"
+            }
+            ChildState::Open => "online",
+            ChildState::Faulted => "faulted",
+            ChildState::Closed => "faulted",
+        }
+        .to_string()
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct NexusChild {
     /// name of the parent this child belongs too
@@ -117,7 +146,6 @@ pub struct NexusChild {
     pub(crate) desc: Option<Arc<Descriptor>>,
     /// current state of the child
     pub(crate) state: ChildState,
-    pub(crate) repairing: bool,
     /// descriptor obtained after opening a device
     #[serde(skip_serializing)]
     pub(crate) bdev_handle: Option<BdevHandle>,
@@ -235,7 +263,6 @@ impl NexusChild {
             ch: std::ptr::null_mut(),
             state: ChildState::Init,
             bdev_handle: None,
-            repairing: false,
         }
     }
 

--- a/mayastor/src/bdev/nexus/nexus_rpc.rs
+++ b/mayastor/src/bdev/nexus/nexus_rpc.rs
@@ -3,7 +3,6 @@ use uuid::Uuid;
 
 use rpc::mayastor::{
     AddChildNexusRequest,
-    Child,
     ChildNexusRequest,
     CreateNexusRequest,
     DestroyNexusRequest,
@@ -82,10 +81,7 @@ pub(crate) fn register_rpc_methods() {
                     children: nexus
                         .children
                         .iter()
-                        .map(|child| Child {
-                            uri: child.name.clone(),
-                            state: child.state.to_string(),
-                        })
+                        .map(|child| nexus.to_rpc_child(child))
                         .collect::<Vec<_>>(),
                     device_path: nexus.get_share_path().unwrap_or_default(),
                     rebuilds: RebuildJob::count() as u64,
@@ -250,7 +246,7 @@ pub(crate) fn register_rpc_methods() {
     jsonrpc_register("get_rebuild_progress", |args: RebuildProgressRequest| {
         let fut = async move {
             let nexus = nexus_lookup(&args.uuid)?;
-            nexus.get_rebuild_progress().await
+            nexus.get_rebuild_progress(&args.uri)
         };
         fut.boxed_local()
     });

--- a/mayastor/src/bdev/nexus/nexus_rpc.rs
+++ b/mayastor/src/bdev/nexus/nexus_rpc.rs
@@ -3,6 +3,7 @@ use uuid::Uuid;
 
 use rpc::mayastor::{
     AddChildNexusRequest,
+    Child,
     ChildNexusRequest,
     CreateNexusRequest,
     DestroyNexusRequest,
@@ -77,11 +78,11 @@ pub(crate) fn register_rpc_methods() {
                 .map(|nexus| RpcNexus {
                     uuid: name_to_uuid(&nexus.name).to_string(),
                     size: nexus.size(),
-                    state: nexus.state.to_string(),
+                    state: nexus.status().to_string(),
                     children: nexus
                         .children
                         .iter()
-                        .map(|child| nexus.to_rpc_child(child))
+                        .map(Child::from)
                         .collect::<Vec<_>>(),
                     device_path: nexus.get_share_path().unwrap_or_default(),
                     rebuilds: RebuildJob::count() as u64,

--- a/mayastor/src/grpc.rs
+++ b/mayastor/src/grpc.rs
@@ -5,9 +5,16 @@ use rpc::{
     service::mayastor_server::{Mayastor, MayastorServer},
 };
 
+use std::convert::From;
+
 use crate::{
     bdev::{
-        nexus::{instances, nexus_bdev, nexus_bdev::Nexus},
+        nexus::{
+            instances,
+            nexus_bdev,
+            nexus_bdev::Nexus,
+            nexus_child::NexusChild,
+        },
         nexus_create,
     },
     core::{Cores, Reactors},
@@ -40,6 +47,16 @@ macro_rules! locally {
         let hdl = Reactors::current().spawn_local($body);
         hdl.await.unwrap()?
     }};
+}
+
+impl From<&NexusChild> for Child {
+    fn from(child: &NexusChild) -> Self {
+        Child {
+            uri: child.name.clone(),
+            state: child.status().to_string(),
+            rebuild_progress: child.get_rebuild_progress(),
+        }
+    }
 }
 
 #[tonic::async_trait]
@@ -156,12 +173,12 @@ impl Mayastor for MayastorGrpc {
             .map(|n| rpc::mayastor::Nexus {
                 uuid: n.name.clone(),
                 size: n.size,
-                state: n.state.to_string(),
+                state: n.status().to_string(),
                 device_path: n.get_share_path().unwrap_or_default(),
                 children: n
                     .children
                     .iter()
-                    .map(|child| n.to_rpc_child(child))
+                    .map(Child::from)
                     .collect::<Vec<_>>(),
                 rebuilds: RebuildJob::count() as u64,
             })

--- a/mayastor/src/grpc.rs
+++ b/mayastor/src/grpc.rs
@@ -161,10 +161,7 @@ impl Mayastor for MayastorGrpc {
                 children: n
                     .children
                     .iter()
-                    .map(|c| Child {
-                        uri: c.name.clone(),
-                        state: c.state.to_string(),
-                    })
+                    .map(|child| n.to_rpc_child(child))
                     .collect::<Vec<_>>(),
                 rebuilds: RebuildJob::count() as u64,
             })
@@ -332,7 +329,7 @@ impl Mayastor for MayastorGrpc {
         let msg = request.into_inner();
 
         Ok(Response::new(locally! { async move {
-            nexus_lookup(&msg.uuid)?.get_rebuild_progress().await
+            nexus_lookup(&msg.uuid)?.get_rebuild_progress(&msg.uri)
         }}))
     }
 }

--- a/mayastor/src/replicas/rebuild/rebuild_api.rs
+++ b/mayastor/src/replicas/rebuild/rebuild_api.rs
@@ -96,13 +96,24 @@ pub struct RebuildJob {
     pub(super) complete_chan: Vec<oneshot::Sender<RebuildState>>,
 }
 
-/// Place holder for rebuild statistics
-pub struct RebuildStats {}
+/// rebuild statistics
+pub struct RebuildStats {
+    /// total number of blocks to recover
+    pub blocks_total: u64,
+    /// number of blocks recovered
+    pub blocks_recovered: u64,
+    /// rebuild progress in % (0-100)
+    pub progress: u64,
+    /// granularity of each recovery copy in blocks
+    pub segment_size_blks: u64,
+    /// size in bytes of each block
+    pub block_size: u64,
+}
 
 /// Public facing operations on a Rebuild Job
 pub trait ClientOperations {
     /// Collects statistics from the job
-    fn stats(&self) -> Option<RebuildStats>;
+    fn stats(&self) -> RebuildStats;
     /// Schedules the job to start in a future and returns a complete channel
     /// which can be waited on
     fn start(

--- a/mayastor/tests/nexus_rebuild.rs
+++ b/mayastor/tests/nexus_rebuild.rs
@@ -88,7 +88,7 @@ fn rebuild_child_faulted() {
         nexus
             .start_rebuild(&get_dev(1))
             .await
-            .expect_err("Rebuild only faulted children!");
+            .expect_err("Rebuild only degraded children!");
 
         nexus.remove_child(&get_dev(1)).await.unwrap();
         assert_eq!(nexus.children.len(), 1);

--- a/rpc/proto/mayastor.proto
+++ b/rpc/proto/mayastor.proto
@@ -152,6 +152,7 @@ message CreateNexusRequest {
 message Child {
   string uri = 1;   // uri of the child device
   string state = 2; // TODO: enum
+  uint64 rebuild_progress = 3;
 }
 
 // represents a nexus device
@@ -242,8 +243,9 @@ message ResumeRebuildRequest {
 
 message RebuildProgressRequest {
   string uuid = 1;  // uuid of the nexus
+  string uri = 2;   // uri of the destination child
 }
 
 message RebuildProgressReply {
-  string progress = 1;  // progress percentage
+  uint64 progress = 1;  // progress percentage
 }

--- a/rpc/proto/mayastor.proto
+++ b/rpc/proto/mayastor.proto
@@ -152,7 +152,7 @@ message CreateNexusRequest {
 message Child {
   string uri = 1;   // uri of the child device
   string state = 2; // TODO: enum
-  uint64 rebuild_progress = 3;
+  int64 rebuild_progress = 3;
 }
 
 // represents a nexus device


### PR DESCRIPTION
Adds a new get_rebuild_progress rpc to indicate the rebuild progress
Also updates the list_nexus child field:
1. adds a rebuild progress to the child
2. maps the child states to a more simplified version for moac

CAS-181
CAS-193
