### PR TITLE
Auto rebuild

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
       - run: /bin/modprobe nbd
       - run: /bin/modprobe xfs
       - run: /bin/modprobe nvme_tcp
-      - run: echo 8192 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+      - run: echo 2048 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
       - run: rm mayastor/.cargo/config
       - run: rm nvmeadm/.cargo/config
       - run: cargo build --all
@@ -55,7 +55,7 @@ jobs:
       - run: ln -s /host/bin/kmod /bin/modprobe
       - run: /bin/modprobe nbd
       - run: /bin/modprobe xfs
-      - run: echo 8192 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+      - run: echo 2048 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
       - run: ( cd mayastor-test && npm install)
       - run: ( cd mayastor-test && ./node_modules/mocha/bin/mocha test_cli.js )
       - run: ( cd mayastor-test && ./node_modules/mocha/bin/mocha test_replica.js )

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
       - run: /bin/modprobe nbd
       - run: /bin/modprobe xfs
       - run: /bin/modprobe nvme_tcp
-      - run: echo 2048 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+      - run: echo 8192 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
       - run: rm mayastor/.cargo/config
       - run: rm nvmeadm/.cargo/config
       - run: cargo build --all
@@ -55,7 +55,7 @@ jobs:
       - run: ln -s /host/bin/kmod /bin/modprobe
       - run: /bin/modprobe nbd
       - run: /bin/modprobe xfs
-      - run: echo 2048 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+      - run: echo 8192 | tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
       - run: ( cd mayastor-test && npm install)
       - run: ( cd mayastor-test && ./node_modules/mocha/bin/mocha test_cli.js )
       - run: ( cd mayastor-test && ./node_modules/mocha/bin/mocha test_replica.js )

--- a/csi/moac/nexus.js
+++ b/csi/moac/nexus.js
@@ -191,7 +191,8 @@ class Nexus {
     try {
       await this.node.call('addChildNexus', {
         uuid: this.uuid,
-        uri: uri
+        uri: uri,
+        rebuild: true
       });
     } catch (err) {
       throw new GrpcError(

--- a/csi/moac/test/mayastor_mock.js
+++ b/csi/moac/test/mayastor_mock.js
@@ -270,7 +270,7 @@ class MayastorServer {
       },
       addChildNexus: (call, cb) => {
         var args = call.request;
-        assertHasKeys(args, ['uuid', 'uri']);
+        assertHasKeys(args, ['uuid', 'uri', 'rebuild']);
         var n = self.nexus.find((n) => n.uuid === args.uuid);
         if (!n) {
           const err = new Error('not found');

--- a/csi/moac/test/nexus_test.js
+++ b/csi/moac/test/nexus_test.js
@@ -43,9 +43,7 @@ module.exports = function () {
         expect(ev.eventType).to.equal('del');
         expect(ev.object).to.equal(nexus);
         setTimeout(() => {
-          // jshint ignore:start
-          expect(nexus.node).to.be.null;
-          // jshint ignore:end
+          expect(nexus.node).to.equal(null);
           done();
         }, 0);
       });
@@ -279,7 +277,8 @@ module.exports = function () {
       sinon.assert.calledOnce(callStub);
       sinon.assert.calledWith(callStub, 'addChildNexus', {
         uuid: UUID,
-        uri: 'iscsi://' + UUID
+        uri: 'iscsi://' + UUID,
+        rebuild: true
       });
       expect(nexus.children).to.have.lengthOf(3);
       // should be sorted according to uri
@@ -307,7 +306,8 @@ module.exports = function () {
       sinon.assert.calledOnce(callStub);
       sinon.assert.calledWith(callStub, 'addChildNexus', {
         uuid: UUID,
-        uri: 'iscsi://' + UUID
+        uri: 'iscsi://' + UUID,
+        rebuild: true
       });
       expect(nexus.children).to.have.lengthOf(2);
       expect(nexus.children[0].uri).to.equal('bdev:///' + UUID);
@@ -372,9 +372,7 @@ module.exports = function () {
       });
       sinon.assert.calledOnce(callStub);
       sinon.assert.calledWith(callStub, 'destroyNexus', { uuid: UUID });
-      // jshint ignore:start
-      expect(nexus.node).to.be.null;
-      // jshint ignore:end
+      expect(nexus.node).to.equal(null);
       expect(node.nexus).to.have.lengthOf(0);
     });
 
@@ -404,9 +402,7 @@ module.exports = function () {
       });
       sinon.assert.calledOnce(callStub);
       sinon.assert.calledWith(callStub, 'destroyNexus', { uuid: UUID });
-      // jshint ignore:start
-      expect(nexus.node).to.be.null;
-      // jshint ignore:end
+      expect(nexus.node).to.equal(null);
       expect(node.nexus).to.have.lengthOf(0);
     });
   });

--- a/csi/moac/test/nexus_test.js
+++ b/csi/moac/test/nexus_test.js
@@ -43,7 +43,7 @@ module.exports = function () {
         expect(ev.eventType).to.equal('del');
         expect(ev.object).to.equal(nexus);
         setTimeout(() => {
-          expect(nexus.node).to.be.null();
+          expect(nexus.node).to.equal(null);
           done();
         }, 0);
       });
@@ -372,7 +372,7 @@ module.exports = function () {
       });
       sinon.assert.calledOnce(callStub);
       sinon.assert.calledWith(callStub, 'destroyNexus', { uuid: UUID });
-      expect(nexus.node).to.be.null();
+      expect(nexus.node).to.equal(null);
       expect(node.nexus).to.have.lengthOf(0);
     });
 
@@ -402,7 +402,7 @@ module.exports = function () {
       });
       sinon.assert.calledOnce(callStub);
       sinon.assert.calledWith(callStub, 'destroyNexus', { uuid: UUID });
-      expect(nexus.node).to.be.null();
+      expect(nexus.node).to.equal(null);
       expect(node.nexus).to.have.lengthOf(0);
     });
   });

--- a/csi/moac/test/nexus_test.js
+++ b/csi/moac/test/nexus_test.js
@@ -43,7 +43,7 @@ module.exports = function () {
         expect(ev.eventType).to.equal('del');
         expect(ev.object).to.equal(nexus);
         setTimeout(() => {
-          expect(nexus.node).to.equal(null);
+          expect(nexus.node).to.be.null();
           done();
         }, 0);
       });
@@ -372,7 +372,7 @@ module.exports = function () {
       });
       sinon.assert.calledOnce(callStub);
       sinon.assert.calledWith(callStub, 'destroyNexus', { uuid: UUID });
-      expect(nexus.node).to.equal(null);
+      expect(nexus.node).to.be.null();
       expect(node.nexus).to.have.lengthOf(0);
     });
 
@@ -402,7 +402,7 @@ module.exports = function () {
       });
       sinon.assert.calledOnce(callStub);
       sinon.assert.calledWith(callStub, 'destroyNexus', { uuid: UUID });
-      expect(nexus.node).to.equal(null);
+      expect(nexus.node).to.be.null();
       expect(node.nexus).to.have.lengthOf(0);
     });
   });

--- a/csi/moac/test/volumes_test.js
+++ b/csi/moac/test/volumes_test.js
@@ -13,7 +13,6 @@ const Node = require('../node');
 const Pool = require('../pool');
 const Registry = require('../registry');
 const Replica = require('../replica');
-const Volume = require('../volume');
 const Volumes = require('../volumes');
 const { GrpcCode } = require('../grpc_client');
 const { shouldFailWith } = require('./utils');
@@ -513,7 +512,8 @@ module.exports = function () {
         expect(stub1.callCount).to.equal(1);
         sinon.assert.calledWithMatch(stub1.firstCall, 'addChildNexus', {
           uuid: UUID,
-          uri: 'nvmf://replica3'
+          uri: 'nvmf://replica3',
+          rebuild: true
         });
         expect(stub2.callCount).to.equal(0);
         expect(stub3.callCount).to.equal(3);
@@ -652,9 +652,7 @@ module.exports = function () {
 
         sinon.assert.calledOnce(stub1);
         sinon.assert.calledWithMatch(stub1, 'unpublishNexus', { uuid: UUID });
-        // jshint ignore:start
-        expect(volume.nexus.devicePath).to.be.empty;
-        // jshint ignore:end
+        expect(volume.nexus.devicePath).to.have.lengthOf(0);
         expect(volEvents).to.have.lengthOf(1);
       });
 
@@ -705,10 +703,8 @@ module.exports = function () {
         sinon.assert.calledWithMatch(stub2, 'destroyReplica', { uuid: UUID });
         sinon.assert.notCalled(stub3);
 
-        // jshint ignore:start
-        expect(volumes.get(UUID)).is.null;
-        expect(volume.nexus).is.null;
-        // jshint ignore:end
+        expect(volumes.get(UUID)).to.equal(null);
+        expect(volume.nexus).to.equal(null);
         expect(Object.keys(volume.replicas)).to.have.length(0);
         // 1 replica, 1 nexus and 1 del volume event
         expect(volEvents).to.have.lengthOf(3);
@@ -718,9 +714,7 @@ module.exports = function () {
         stub1.onCall(0).resolves({});
         stub2.onCall(0).resolves({});
         stub3.onCall(0).resolves({});
-        // jshint ignore:start
-        expect(volumes.get(UUID)).is.null;
-        // jshint ignore:end
+        expect(volumes.get(UUID)).to.equal(null);
 
         await volumes.destroyVolume(UUID);
 

--- a/csi/moac/test/volumes_test.js
+++ b/csi/moac/test/volumes_test.js
@@ -652,7 +652,7 @@ module.exports = function () {
 
         sinon.assert.calledOnce(stub1);
         sinon.assert.calledWithMatch(stub1, 'unpublishNexus', { uuid: UUID });
-        expect(volume.nexus.devicePath).to.have.lengthOf(0);
+        expect(volume.nexus.devicePath).to.be.empty();
         expect(volEvents).to.have.lengthOf(1);
       });
 
@@ -703,8 +703,8 @@ module.exports = function () {
         sinon.assert.calledWithMatch(stub2, 'destroyReplica', { uuid: UUID });
         sinon.assert.notCalled(stub3);
 
-        expect(volumes.get(UUID)).to.equal(null);
-        expect(volume.nexus).to.equal(null);
+        expect(volumes.get(UUID)).to.be.null();
+        expect(volume.nexus).to.be.null();
         expect(Object.keys(volume.replicas)).to.have.length(0);
         // 1 replica, 1 nexus and 1 del volume event
         expect(volEvents).to.have.lengthOf(3);
@@ -714,7 +714,7 @@ module.exports = function () {
         stub1.onCall(0).resolves({});
         stub2.onCall(0).resolves({});
         stub3.onCall(0).resolves({});
-        expect(volumes.get(UUID)).to.equal(null);
+        expect(volumes.get(UUID)).to.be.null();
 
         await volumes.destroyVolume(UUID);
 

--- a/csi/moac/test/volumes_test.js
+++ b/csi/moac/test/volumes_test.js
@@ -652,7 +652,7 @@ module.exports = function () {
 
         sinon.assert.calledOnce(stub1);
         sinon.assert.calledWithMatch(stub1, 'unpublishNexus', { uuid: UUID });
-        expect(volume.nexus.devicePath).to.be.empty();
+        expect(volume.nexus.devicePath).to.have.lengthOf(0);
         expect(volEvents).to.have.lengthOf(1);
       });
 
@@ -703,8 +703,8 @@ module.exports = function () {
         sinon.assert.calledWithMatch(stub2, 'destroyReplica', { uuid: UUID });
         sinon.assert.notCalled(stub3);
 
-        expect(volumes.get(UUID)).to.be.null();
-        expect(volume.nexus).to.be.null();
+        expect(volumes.get(UUID)).to.equal(null);
+        expect(volume.nexus).to.equal(null);
         expect(Object.keys(volume.replicas)).to.have.length(0);
         // 1 replica, 1 nexus and 1 del volume event
         expect(volEvents).to.have.lengthOf(3);
@@ -714,7 +714,7 @@ module.exports = function () {
         stub1.onCall(0).resolves({});
         stub2.onCall(0).resolves({});
         stub3.onCall(0).resolves({});
-        expect(volumes.get(UUID)).to.be.null();
+        expect(volumes.get(UUID)).to.equal(null);
 
         await volumes.destroyVolume(UUID);
 

--- a/mayastor-test/test_nexus.js
+++ b/mayastor-test/test_nexus.js
@@ -363,7 +363,8 @@ describe('nexus', function () {
   it('should be able to add the child back', (done) => {
     const args = {
       uuid: UUID,
-      uri: 'nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:disk2'
+      uri: 'nvmf://127.0.0.1:8420/nqn.2019-05.io.openebs:disk2',
+      rebuild: true
     };
 
     client.AddChildNexus(args, (err) => {

--- a/mayastor-test/test_rebuild.js
+++ b/mayastor-test/test_rebuild.js
@@ -74,6 +74,12 @@ const rebuildArgs = {
   uri: `aio:///${child2}?blk_size=4096`
 };
 
+const addChildArgs = {
+  uuid: UUID,
+  uri: `aio:///${child2}?blk_size=4096`,
+  rebuild: false
+};
+
 const childOnlineArgs = {
   uuid: UUID,
   uri: `aio:///${child2}?blk_size=4096`,
@@ -121,7 +127,7 @@ describe('rebuild tests', function () {
   };
 
   async function checkState (childType, expectedState) {
-    const res = await client.listNexus().sendMessage(rebuildArgs);
+    const res = await client.listNexus().sendMessage();
     assert.lengthOf(res.nexusList, 1);
 
     const nexus = res.nexusList[0];
@@ -137,7 +143,7 @@ describe('rebuild tests', function () {
   }
 
   async function checkNumRebuilds (expected) {
-    const res = await client.listNexus().sendMessage(rebuildArgs);
+    const res = await client.listNexus().sendMessage();
     assert.lengthOf(res.nexusList, 1);
 
     const nexus = res.nexusList[0];
@@ -240,7 +246,7 @@ describe('rebuild tests', function () {
 
   describe('running rebuild', function () {
     beforeEach(async () => {
-      await client.addChildNexus().sendMessage(rebuildArgs);
+      await client.addChildNexus().sendMessage(addChildArgs);
       await client.startRebuild().sendMessage(rebuildArgs);
     });
 
@@ -272,7 +278,7 @@ describe('rebuild tests', function () {
 
   describe('stopping rebuild', function () {
     beforeEach(async () => {
-      await client.addChildNexus().sendMessage(rebuildArgs);
+      await client.addChildNexus().sendMessage(addChildArgs);
       await client.startRebuild().sendMessage(rebuildArgs);
       await client.stopRebuild().sendMessage(rebuildArgs);
       // TODO: Check for rebuild stop rather than sleeping
@@ -318,7 +324,7 @@ describe('rebuild tests', function () {
 
   describe('pausing rebuild', function () {
     beforeEach(async () => {
-      await client.addChildNexus().sendMessage(rebuildArgs);
+      await client.addChildNexus().sendMessage(addChildArgs);
       await client.startRebuild().sendMessage(rebuildArgs);
       await client.pauseRebuild().sendMessage(rebuildArgs);
     });
@@ -353,7 +359,7 @@ describe('rebuild tests', function () {
 
   describe('resuming rebuild', function () {
     beforeEach(async () => {
-      await client.addChildNexus().sendMessage(rebuildArgs);
+      await client.addChildNexus().sendMessage(addChildArgs);
       await client.startRebuild().sendMessage(rebuildArgs);
       await client.pauseRebuild().sendMessage(rebuildArgs);
       await client.resumeRebuild().sendMessage(rebuildArgs);
@@ -389,7 +395,7 @@ describe('rebuild tests', function () {
 
   describe('set child online', function () {
     beforeEach(async () => {
-      await client.addChildNexus().sendMessage(rebuildArgs);
+      await client.addChildNexus().sendMessage(addChildArgs);
       await client.childOperation().sendMessage(childOfflineArgs);
       await client.childOperation().sendMessage(childOnlineArgs);
     });
@@ -422,7 +428,7 @@ describe('rebuild tests', function () {
 
   describe('set child offline', function () {
     beforeEach(async () => {
-      await client.addChildNexus().sendMessage(rebuildArgs);
+      await client.addChildNexus().sendMessage(addChildArgs);
       await client.startRebuild().sendMessage(rebuildArgs);
       await client.childOperation().sendMessage(childOfflineArgs);
     });

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -163,8 +163,16 @@ pub enum Error {
         child: String,
         name: String,
     },
-    #[snafu(display(""))]
-    RebuildOperationError { source: RebuildError },
+    #[snafu(display(
+        "Failed to execute rebuild operation on job {} of nexus {}",
+        child,
+        name,
+    ))]
+    RebuildOperationError {
+        child: String,
+        name: String,
+        source: RebuildError,
+    },
     #[snafu(display("Invalid ShareProtocol value {}", sp_value))]
     InvalidShareProtocol { sp_value: i32 },
     #[snafu(display("Failed to create nexus {}", name))]

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -17,7 +17,8 @@
 //!
 //! `add_child` will construct a new `NexusChild` and add the bdev given by the
 //! uri to the nexus. The nexus will transition to degraded mode as the new
-//! child requires rebuild first.
+//! child requires rebuild first. If the rebuild flag is set then the rebuild
+//! is also started otherwise it has to be started through `start_rebuild`.
 //!
 //! When reconfiguring the nexus, we traverse all our children, create new IO
 //! channels for all children that are in the open state.
@@ -92,12 +93,14 @@ impl Nexus {
     ///
     /// The child may require a rebuild first, so the nexus will
     /// transition to degraded mode when the addition has been successful.
-    pub async fn add_child(&mut self, uri: &str) -> Result<NexusStatus, Error> {
+    pub async fn add_child(
+        &mut self,
+        uri: &str,
+        rebuild: bool,
+    ) -> Result<NexusStatus, Error> {
         let name = bdev_create(&uri).await.context(CreateChild {
             name: self.name.clone(),
         })?;
-
-        trace!("adding child {} to nexus {}", name, self.name);
 
         let child_bdev = match Bdev::lookup_by_name(&name) {
             Some(child) => {
@@ -150,6 +153,17 @@ impl Nexus {
                 if let Err(e) = self.sync_labels().await {
                     error!("Failed to sync labels {:?}", e);
                     // todo: how to signal this?
+                }
+
+                if rebuild {
+                    if let Err(e) = self.start_rebuild(&name) {
+                        error!(
+                            "Failed to automatically start the rebuild: {}",
+                            e
+                        );
+                        // todo: How to notify the control plane?
+                        // or fail the add even?
+                    }
                 }
 
                 Ok(self.status())
@@ -234,7 +248,7 @@ impl Nexus {
                 name: self.name.clone(),
             })?;
             child.out_of_sync(true);
-            self.start_rebuild_rpc(name).await?;
+            self.start_rebuild(name).map(|_| {})?;
             Ok(self.status())
         } else {
             Err(Error::ChildNotFound {

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -94,7 +94,7 @@ impl Nexus {
     /// The child may require a rebuild first, so the nexus will
     /// transition to degraded mode when the addition has been successful.
     /// The rebuild flag dictates wether we attempt to start the rebuild or not
-    /// If the rebuild fails to starts the child remains degraded until such
+    /// If the rebuild fails to start the child remains degraded until such
     /// time the rebuild is retried and complete
     pub async fn add_child(
         &mut self,

--- a/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
@@ -21,16 +21,9 @@ use crate::{
 };
 
 impl Nexus {
-    /// Starts a rebuild job in the background
-    pub async fn start_rebuild_rpc(&mut self, name: &str) -> Result<(), Error> {
-        // we don't need the rust channel on rpc
-        let _ = self.start_rebuild(name).await?;
-        Ok(())
-    }
-
     /// Starts a rebuild job and returns a receiver channel
     /// which can be used to await the rebuild completion
-    pub async fn start_rebuild(
+    pub fn start_rebuild(
         &mut self,
         name: &str,
     ) -> Result<Receiver<RebuildState>, Error> {
@@ -78,7 +71,7 @@ impl Nexus {
             name: self.name.clone(),
         })?;
 
-        job.as_client().start().context(CreateRebuildError {
+        job.as_client().start().context(RebuildOperationError {
             child: name.to_owned(),
             name: self.name.clone(),
         })
@@ -99,7 +92,10 @@ impl Nexus {
     /// Stop a rebuild job in the background
     pub async fn stop_rebuild(&self, name: &str) -> Result<(), Error> {
         match self.get_rebuild_job(name) {
-            Ok(rj) => rj.as_client().stop().context(RebuildOperationError {}),
+            Ok(rj) => rj.as_client().stop().context(RebuildOperationError {
+                child: name.to_owned(),
+                name: self.name.clone(),
+            }),
             // If a rebuild task is not found return ok
             // as we were just going to remove it anyway.
             Err(_) => Ok(()),
@@ -109,13 +105,19 @@ impl Nexus {
     /// Pause a rebuild job in the background
     pub async fn pause_rebuild(&mut self, name: &str) -> Result<(), Error> {
         let rj = self.get_rebuild_job(name)?.as_client();
-        rj.pause().context(RebuildOperationError {})
+        rj.pause().context(RebuildOperationError {
+            child: name.to_owned(),
+            name: self.name.clone(),
+        })
     }
 
     /// Resume a rebuild job in the background
     pub async fn resume_rebuild(&mut self, name: &str) -> Result<(), Error> {
         let rj = self.get_rebuild_job(name)?.as_client();
-        rj.resume().context(RebuildOperationError {})
+        rj.resume().context(RebuildOperationError {
+            child: name.to_owned(),
+            name: self.name.clone(),
+        })
     }
 
     /// Return the state of a rebuild job
@@ -146,7 +148,7 @@ impl Nexus {
     /// stopped. If any job is found with the child as a source then
     /// the job is replaced with a new one with another healthy child
     /// as src, if found
-    /// todo: how to proceed if not healthy child is found?
+    /// todo: how to proceed if no healthy child is found?
     pub async fn cancel_child_rebuild_jobs(&mut self, name: &str) {
         let mut src_jobs = self.get_rebuild_job_src(name);
 
@@ -165,7 +167,7 @@ impl Nexus {
                 error!("Error {} when waiting for the job to terminate", e);
             }
 
-            if let Err(e) = self.start_rebuild(&job.0).await {
+            if let Err(e) = self.start_rebuild(&job.0) {
                 error!("Failed to recreate rebuild: {}", e);
             }
         }

--- a/mayastor/src/bdev/nexus/nexus_rpc.rs
+++ b/mayastor/src/bdev/nexus/nexus_rpc.rs
@@ -166,7 +166,7 @@ pub(crate) fn register_rpc_methods() {
     jsonrpc_register("add_child_nexus", |args: AddChildNexusRequest| {
         let fut = async move {
             let nexus = nexus_lookup(&args.uuid)?;
-            nexus.add_child(&args.uri).await.map(|_| ())
+            nexus.add_child(&args.uri, args.rebuild).await.map(|_| ())
         };
         fut.boxed_local()
     });
@@ -182,7 +182,7 @@ pub(crate) fn register_rpc_methods() {
     jsonrpc_register("start_rebuild", |args: StartRebuildRequest| {
         let fut = async move {
             let nexus = nexus_lookup(&args.uuid)?;
-            nexus.start_rebuild_rpc(&args.uri).await
+            nexus.start_rebuild(&args.uri).map(|_| {})
         };
         fut.boxed_local()
     });

--- a/mayastor/src/grpc.rs
+++ b/mayastor/src/grpc.rs
@@ -200,7 +200,7 @@ impl Mayastor for MayastorGrpc {
     ) -> Result<Response<Null>> {
         let msg = request.into_inner();
         locally! { async move {
-            nexus_lookup(&msg.uuid)?.add_child(&msg.uri).await.map(|_| ())
+            nexus_lookup(&msg.uuid)?.add_child(&msg.uri, msg.rebuild).await.map(|_| ())
         }};
 
         Ok(Response::new(Null {}))
@@ -292,7 +292,7 @@ impl Mayastor for MayastorGrpc {
     ) -> Result<Response<Null>> {
         let msg = request.into_inner();
         locally! { async move {
-            nexus_lookup(&msg.uuid)?.start_rebuild_rpc(&msg.uri).await
+            nexus_lookup(&msg.uuid)?.start_rebuild(&msg.uri).map(|_|{})
         }};
 
         Ok(Response::new(Null {}))

--- a/mayastor/tests/nexus_rebuild.rs
+++ b/mayastor/tests/nexus_rebuild.rs
@@ -49,6 +49,32 @@ fn rebuild_test() {
 }
 
 #[test]
+// test the rebuild flag of the add_child operation
+fn rebuild_test_add() {
+    test_ini();
+
+    Reactor::block_on(async {
+        nexus_create(1).await;
+        let nexus = nexus_lookup(NEXUS_NAME).unwrap();
+
+        nexus.add_child(&get_dev(1), true).await.unwrap();
+        nexus
+            .start_rebuild(&get_dev(1))
+            .expect_err("rebuild expected to be present");
+        nexus_test_child(1).await;
+
+        nexus.add_child(&get_dev(2), false).await.unwrap();
+        let _ = nexus
+            .start_rebuild(&get_dev(2))
+            .expect("rebuild not expected to be present");
+
+        nexus_lookup(NEXUS_NAME).unwrap().destroy().await.unwrap();
+    });
+
+    test_fini();
+}
+
+#[test]
 fn rebuild_progress() {
     test_ini();
 

--- a/mayastor/tests/nexus_rebuild.rs
+++ b/mayastor/tests/nexus_rebuild.rs
@@ -87,14 +87,12 @@ fn rebuild_child_faulted() {
         let nexus = nexus_lookup(NEXUS_NAME).unwrap();
         nexus
             .start_rebuild(&get_dev(1))
-            .await
             .expect_err("Rebuild only degraded children!");
 
         nexus.remove_child(&get_dev(1)).await.unwrap();
         assert_eq!(nexus.children.len(), 1);
         nexus
             .start_rebuild(&get_dev(0))
-            .await
             .expect_err("Cannot rebuild from the same child");
 
         nexus.destroy().await.unwrap();
@@ -179,8 +177,7 @@ async fn nexus_create(children: u64) {
 async fn nexus_add_child(new_child: u64, wait: bool) {
     let nexus = nexus_lookup(NEXUS_NAME).unwrap();
 
-    nexus.add_child(&get_dev(new_child)).await.unwrap();
-    let _ = nexus.start_rebuild(&get_dev(new_child)).await.unwrap();
+    nexus.add_child(&get_dev(new_child), true).await.unwrap();
 
     if wait {
         common::wait_for_rebuild(

--- a/rpc/proto/mayastor.proto
+++ b/rpc/proto/mayastor.proto
@@ -178,6 +178,7 @@ message DestroyNexusRequest   {
 message AddChildNexusRequest {
   string uuid = 1;    // uuid of the nexus
   string uri = 2;     // URI of the child device to be added
+  bool rebuild = 3;   // auto start rebuilding
 }
 
 message RemoveChildNexusRequest {


### PR DESCRIPTION
Automatically rebuild when adding a new child

When a  child is added the control plane expects mayastor to rebuild
the child. Added a new parameter to add_child which allows for this
whilst also allowing for a finer grained control over rebuild.

Adjusted all the required tests for this including semistandard fixes

Resolves CAS-149
