### PR TITLE
rebuild: more testing bug fixes (cas-246)

### DIFF
--- a/mayastor/src/bdev/mod.rs
+++ b/mayastor/src/bdev/mod.rs
@@ -3,7 +3,13 @@ use std::ffi::CStr;
 pub use aio_dev::{AioBdev, AioParseError};
 pub use iscsi_dev::{IscsiBdev, IscsiParseError};
 pub use nexus::{
-    nexus_bdev::{nexus_create, nexus_lookup, Nexus, NexusStatus},
+    nexus_bdev::{
+        nexus_create,
+        nexus_lookup,
+        Nexus,
+        NexusStatus,
+        VerboseError,
+    },
     nexus_label::{GPTHeader, GptEntry},
     nexus_metadata_content::{
         NexusConfig,

--- a/mayastor/src/bdev/nexus/nexus_bdev.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev.rs
@@ -53,6 +53,23 @@ use crate::{
     rebuild::RebuildError,
 };
 
+pub trait VerboseError {
+    fn verbose(&self) -> String;
+}
+
+impl VerboseError for Error {
+    fn verbose(&self) -> String {
+        let err = self as &dyn std::error::Error;
+        let mut msg = format!("{}", err);
+        let mut opt_source = err.source();
+        while let Some(source) = opt_source {
+            msg = format!("{}: {}", msg, source);
+            opt_source = source.source();
+        }
+        msg
+    }
+}
+
 /// Common errors for nexus basic operations and child operations
 /// which are part of nexus object.
 #[derive(Debug, Snafu)]
@@ -136,7 +153,7 @@ pub enum Error {
     #[snafu(display(
         "Failed to create rebuild job for child {} of nexus {}",
         child,
-        name
+        name,
     ))]
     CreateRebuildError {
         source: RebuildError,

--- a/mayastor/src/bdev/nexus/nexus_bdev_children.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_children.rs
@@ -133,6 +133,7 @@ impl Nexus {
                             err
                         );
                     }
+
                     return Err(Error::ChildGeometry {
                         child: name,
                         name: self.name.clone(),
@@ -243,7 +244,7 @@ impl Nexus {
     }
 
     /// online a child and reconfigure the IO channels. The child is already
-    /// registered, but simpy not opened. This can be required in case where
+    /// registered, but simply not opened. This can be required in case where
     /// a child is misbehaving.
     pub async fn online_child(
         &mut self,

--- a/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
+++ b/mayastor/src/bdev/nexus/nexus_bdev_rebuild.rs
@@ -58,8 +58,10 @@ impl Nexus {
             &self.name,
             &src_child_name,
             &dst_child.name,
-            self.data_ent_offset,
-            self.bdev.num_blocks() + self.data_ent_offset,
+            std::ops::Range::<u64> {
+                start: self.data_ent_offset,
+                end: self.bdev.num_blocks() + self.data_ent_offset,
+            },
             |nexus, job| {
                 Reactors::current().send_future(async move {
                     Nexus::notify_rebuild(nexus, job).await;

--- a/mayastor/src/replicas/mod.rs
+++ b/mayastor/src/replicas/mod.rs
@@ -7,4 +7,5 @@ pub mod rebuild {
     pub mod rebuild_impl;
 
     pub use rebuild_api::*;
+    pub use rebuild_impl::SEGMENT_SIZE;
 }

--- a/mayastor/src/replicas/rebuild/rebuild_api.rs
+++ b/mayastor/src/replicas/rebuild/rebuild_api.rs
@@ -72,18 +72,18 @@ impl fmt::Display for RebuildState {
 
 /// A rebuild job is responsible for managing a rebuild (copy) which reads
 /// from source_hdl and writes into destination_hdl from specified start to end
+#[derive(Debug)]
 pub struct RebuildJob {
     /// name of the nexus associated with the rebuild job
     pub nexus: String,
     /// source URI of the healthy child to rebuild from
-    pub(super) source: String,
+    pub source: String,
     pub(super) source_hdl: BdevHandle,
     /// target URI of the out of sync child in need of a rebuild
     pub destination: String,
     pub(super) destination_hdl: BdevHandle,
     pub(super) block_size: u64,
-    pub(super) start: u64,
-    pub(super) end: u64,
+    pub(super) range: std::ops::Range<u64>,
     pub(super) next: u64,
     pub(super) segment_size_blks: u64,
     pub(super) tasks: RebuildTasks,
@@ -141,12 +141,10 @@ impl RebuildJob {
         nexus: &str,
         source: &str,
         destination: &'a str,
-        start: u64,
-        end: u64,
+        range: std::ops::Range<u64>,
         notify_fn: fn(String, String) -> (),
     ) -> Result<&'a mut Self, RebuildError> {
-        Self::new(nexus, source, destination, start, end, notify_fn)?
-            .store()?;
+        Self::new(nexus, source, destination, range, notify_fn)?.store()?;
 
         Ok(Self::lookup(destination)?)
     }
@@ -164,20 +162,17 @@ impl RebuildJob {
 
     /// Lookup all rebuilds jobs with name as its source
     pub fn lookup_src(name: &str) -> Vec<&mut Self> {
-        let mut jobs = Vec::new();
-
         Self::get_instances()
             .iter_mut()
             .filter(|j| j.1.source == name)
-            .for_each(|j| jobs.push(j.1));
-
-        jobs
+            .map(|j| j.1.as_mut())
+            .collect::<Vec<_>>()
     }
 
     /// Lookup a rebuild job by its destination uri then remove and return it
     pub fn remove(name: &str) -> Result<Self, RebuildError> {
         match Self::get_instances().remove(name) {
-            Some(job) => Ok(job),
+            Some(job) => Ok(*job),
             None => Err(RebuildError::JobNotFound {
                 job: name.to_owned(),
             }),

--- a/mayastor/src/replicas/rebuild/rebuild_impl.rs
+++ b/mayastor/src/replicas/rebuild/rebuild_impl.rs
@@ -16,7 +16,7 @@ use super::rebuild_api::*;
 
 /// Global list of rebuild jobs using a static OnceCell
 pub(super) struct RebuildInstances {
-    inner: UnsafeCell<HashMap<String, RebuildJob>>,
+    inner: UnsafeCell<HashMap<String, Box<RebuildJob>>>,
 }
 
 unsafe impl Sync for RebuildInstances {}
@@ -25,6 +25,7 @@ unsafe impl Send for RebuildInstances {}
 /// Result returned by each segment task worker
 /// used to communicate with the management task indicating that the
 /// segment task worker is ready to copy another segment
+#[derive(Debug)]
 struct TaskResult {
     /// block that was being rebuilt
     blk: u64,
@@ -37,12 +38,13 @@ struct TaskResult {
 /// Number of concurrent copy tasks per rebuild job
 const SEGMENT_TASKS: u64 = 4;
 /// Size of each segment used by the copy task
-const SEGMENT_SIZE: u64 = 10 * 1024; // 10KiB
+pub const SEGMENT_SIZE: u64 = 10 * 1024; // 10KiB
 
 /// Each rebuild task needs a unique buffer to read/write from source to target
 /// a mpsc channel is used to communicate with the management task and each
 /// task used a clone of the sender allowing the management to poll a single
 /// receiver
+#[derive(Debug)]
 pub(super) struct RebuildTasks {
     buffers: Vec<DmaBuf>,
     senders: Vec<mpsc::Sender<TaskResult>>,
@@ -52,6 +54,22 @@ pub(super) struct RebuildTasks {
     total: u64,
 
     segments_done: u64,
+}
+
+/// Checks whether a range is contained within another range
+pub trait Within<T> {
+    /// True if `right` is contained within `self`, otherwise false
+    fn within(&self, right: std::ops::Range<T>) -> bool;
+}
+
+impl Within<u64> for std::ops::Range<u64> {
+    fn within(&self, right: std::ops::Range<u64>) -> bool {
+        // also make sure ranges don't overflow
+        self.start < self.end
+            && right.start < right.end
+            && self.start >= right.start
+            && self.end <= right.end
+    }
 }
 
 impl RebuildJob {
@@ -64,7 +82,8 @@ impl RebuildJob {
                 job: self.destination,
             })
         } else {
-            let _ = rebuild_list.insert(self.destination.clone(), self);
+            let _ =
+                rebuild_list.insert(self.destination.clone(), Box::new(self));
             Ok(())
         }
     }
@@ -74,8 +93,7 @@ impl RebuildJob {
         nexus: &str,
         source: &str,
         destination: &str,
-        start: u64,
-        end: u64,
+        range: std::ops::Range<u64>,
         notify_fn: fn(String, String) -> (),
     ) -> Result<Self, RebuildError> {
         let source_hdl =
@@ -87,8 +105,11 @@ impl RebuildJob {
                 bdev: destination,
             })?;
 
-        if !Self::validate(&source_hdl.get_bdev(), &destination_hdl.get_bdev())
-        {
+        if !Self::validate(
+            &source_hdl.get_bdev(),
+            &destination_hdl.get_bdev(),
+            &range,
+        ) {
             return Err(RebuildError::InvalidParameters {});
         };
 
@@ -127,9 +148,8 @@ impl RebuildJob {
             source_hdl,
             destination,
             destination_hdl,
-            start,
-            end,
-            next: start,
+            next: range.start,
+            range,
             block_size,
             segment_size_blks,
             tasks,
@@ -187,12 +207,13 @@ impl RebuildJob {
     ) -> Result<(), RebuildError> {
         let mut copy_buffer: DmaBuf;
 
-        let mut copy_buffer = if (blk + self.segment_size_blks) > self.end {
-            let segment_size_blks = self.end - blk;
+        let mut copy_buffer = if (blk + self.segment_size_blks) > self.range.end
+        {
+            let segment_size_blks = self.range.end - blk;
 
             trace!(
-                    "Adjusting last segment size from {} to {}. offset: {}, start: {}, end: {}",
-                    self.segment_size_blks, segment_size_blks, blk, self.start, self.end,
+                    "Adjusting last segment size from {} to {}. offset: {}, range: {:?}",
+                    self.segment_size_blks, segment_size_blks, blk, self.range,
                 );
 
             copy_buffer = self
@@ -238,9 +259,16 @@ impl RebuildJob {
 
     /// Check if the source and destination block devices are compatible for
     /// rebuild
-    fn validate(source: &Bdev, destination: &Bdev) -> bool {
-        !(source.size_in_bytes() != destination.size_in_bytes()
-            || source.block_len() != destination.block_len())
+    fn validate(
+        source: &Bdev,
+        destination: &Bdev,
+        range: &std::ops::Range<u64>,
+    ) -> bool {
+        // todo: make sure we don't overwrite the labels
+        let data_partition_start = 0;
+        range.within(data_partition_start .. source.num_blocks())
+            && range.within(data_partition_start .. destination.num_blocks())
+            && source.block_len() == destination.block_len()
     }
 
     /// reconcile the pending state to the current and clear the pending
@@ -292,7 +320,7 @@ impl RebuildJob {
 
     /// Get the rebuild job instances container, we ensure that this can only
     /// ever be called on a properly allocated thread
-    pub(super) fn get_instances() -> &'static mut HashMap<String, Self> {
+    pub(super) fn get_instances() -> &'static mut HashMap<String, Box<Self>> {
         let thread = unsafe { spdk_get_thread() };
         if thread.is_null() {
             panic!("not called from SPDK thread")
@@ -338,7 +366,7 @@ impl std::fmt::Display for RebuildOperation {
 
 impl ClientOperations for RebuildJob {
     fn stats(&self) -> RebuildStats {
-        let blocks_total = self.end - self.start;
+        let blocks_total = self.range.end - self.range.start;
 
         // segment size may not be aligned to the total size
         let blocks_recovered = std::cmp::min(
@@ -349,13 +377,12 @@ impl ClientOperations for RebuildJob {
         let progress = (blocks_recovered * 100) / blocks_total;
 
         info!(
-            "State: {}, Src: {}, Dst: {}, start: {}, end: {}, next: {}, \
+            "State: {}, Src: {}, Dst: {}, range: {:?}, next: {}, \
              block_size: {}, segment_sz: {}, recovered_blks: {}, progress: {}%",
             self.state(),
             self.source,
             self.destination,
-            self.start,
-            self.end,
+            self.range,
             self.next,
             self.block_size,
             self.segment_size_blks,
@@ -470,12 +497,14 @@ impl RebuildJob {
     /// Sends one segment worth of data in a reactor future and notifies the
     /// management channel. Returns the next segment offset to rebuild, if any
     fn send_segment_task(&self, id: u64) -> Option<u64> {
-        if self.next >= self.end {
+        if self.next >= self.range.end {
             None
         } else {
             let blk = self.next;
-            let next =
-                std::cmp::min(self.next + self.segment_size_blks, self.end);
+            let next = std::cmp::min(
+                self.next + self.segment_size_blks,
+                self.range.end,
+            );
             let name = self.destination.clone();
 
             Reactors::current().send_future(async move {
@@ -615,12 +644,12 @@ impl RebuildJob {
                     S::Running => {
                         self.states
                             .set_pending(S::Stopped, override_pending)?;
+
                         Ok(())
                     }
                     S::Init | S::Paused => {
                         self.states
                             .set_pending(S::Stopped, override_pending)?;
-
                         // The rebuild is not running so we need to reconcile
                         self.reconcile();
                         Ok(())

--- a/mayastor/tests/nexus_metadata.rs
+++ b/mayastor/tests/nexus_metadata.rs
@@ -65,7 +65,7 @@ async fn read_write_metadata() {
             .map(String::from)
             .collect(),
         revision: 38,
-        checksum: 0x3c2d38ab,
+        checksum: 0x3c2d_38ab,
         data: String::from("Hello from v1"),
     }));
 
@@ -76,7 +76,7 @@ async fn read_write_metadata() {
             .map(String::from)
             .collect(),
         revision: 40,
-        checksum: 0x3c2e40ab,
+        checksum: 0x3c2e_40ab,
         data: String::from("Hello from v2"),
         count: 100,
     }));
@@ -84,7 +84,7 @@ async fn read_write_metadata() {
     data.push(NexusConfig::Version3(NexusConfigVersion3 {
         name: "Hello".to_string(),
         revision: 42,
-        checksum: 0x3c2f42ab,
+        checksum: 0x3c2f_42ab,
         data: String::from("Hello from v3")
             .split_whitespace()
             .map(String::from)

--- a/mayastor/tests/nexus_rebuild.rs
+++ b/mayastor/tests/nexus_rebuild.rs
@@ -3,22 +3,36 @@ use crossbeam::channel::unbounded;
 pub mod common;
 
 use mayastor::{
-    bdev::nexus_lookup,
+    bdev::{nexus_lookup, VerboseError},
     core::{MayastorCliArgs, MayastorEnvironment, Reactor},
-    replicas::rebuild::RebuildState,
+    replicas::rebuild::{RebuildJob, RebuildState, SEGMENT_SIZE},
 };
 
+use once_cell::sync::Lazy;
 use rpc::mayastor::ShareProtocolNexus;
+use std::sync::Mutex;
 
-const NEXUS_NAME: &str = "rebuild_test_nexus";
-const NEXUS_SIZE: u64 = 10 * 1024 * 1024; // 10MiB
+// each test `should` use a different nexus name to prevent clashing with
+// one another. This allows the failed tests to `panic gracefully` improving
+// the output log and allowing the CI to fail gracefully as well
+static NEXUS_NAME: Lazy<Mutex<&str>> = Lazy::new(|| Mutex::new("Default"));
+pub fn nexus_name() -> &'static str {
+    &NEXUS_NAME.lock().unwrap()
+}
+
+static NEXUS_SIZE: u64 = 5 * 1024 * 1024; // 10MiB
+
+// approximate on-disk metadata that will be written to the child by the nexus
+const META_SIZE: u64 = 5 * 1024 * 1024; // 5MiB
 const MAX_CHILDREN: u64 = 16;
 
-fn test_ini() {
+fn test_ini(name: &'static str) {
+    *NEXUS_NAME.lock().unwrap() = name;
+
     test_init!();
     for i in 0 .. MAX_CHILDREN {
         common::delete_file(&[get_disk(i)]);
-        common::truncate_file_bytes(&get_disk(i), NEXUS_SIZE);
+        common::truncate_file_bytes(&get_disk(i), NEXUS_SIZE + META_SIZE);
     }
 }
 fn test_fini() {
@@ -32,17 +46,17 @@ fn get_disk(number: u64) -> String {
     format!("/tmp/disk{}.img", number)
 }
 fn get_dev(number: u64) -> String {
-    format!("aio://{}?blk_size=512", get_disk(number))
+    format!("aio://{}_{}?blk_size=512", nexus_name(), get_disk(number))
 }
 
 #[test]
-fn rebuild_test() {
-    test_ini();
+fn rebuild_test_basic() {
+    test_ini("rebuild_test_basic");
 
     Reactor::block_on(async {
         nexus_create(1).await;
         nexus_add_child(1, true).await;
-        nexus_lookup(NEXUS_NAME).unwrap().destroy().await.unwrap();
+        nexus_lookup(nexus_name()).unwrap().destroy().await.unwrap();
     });
 
     test_fini();
@@ -51,11 +65,11 @@ fn rebuild_test() {
 #[test]
 // test the rebuild flag of the add_child operation
 fn rebuild_test_add() {
-    test_ini();
+    test_ini("rebuild_test_add");
 
     Reactor::block_on(async {
         nexus_create(1).await;
-        let nexus = nexus_lookup(NEXUS_NAME).unwrap();
+        let nexus = nexus_lookup(nexus_name()).unwrap();
 
         nexus.add_child(&get_dev(1), true).await.unwrap();
         nexus
@@ -68,7 +82,7 @@ fn rebuild_test_add() {
             .start_rebuild(&get_dev(2))
             .expect("rebuild not expected to be present");
 
-        nexus_lookup(NEXUS_NAME).unwrap().destroy().await.unwrap();
+        nexus_lookup(nexus_name()).unwrap().destroy().await.unwrap();
     });
 
     test_fini();
@@ -76,10 +90,10 @@ fn rebuild_test_add() {
 
 #[test]
 fn rebuild_progress() {
-    test_ini();
+    test_ini("rebuild_progress");
 
     async fn test_progress(polls: u64, progress: u64) -> u64 {
-        let nexus = nexus_lookup(NEXUS_NAME).unwrap();
+        let nexus = nexus_lookup(nexus_name()).unwrap();
         nexus.resume_rebuild(&get_dev(1)).await.unwrap();
         // { polls } to poll with an expr rather than an ident
         reactor_poll!({ polls });
@@ -97,7 +111,7 @@ fn rebuild_progress() {
         for _ in 0 .. 10 {
             progress = test_progress(50, progress).await;
         }
-        nexus_lookup(NEXUS_NAME).unwrap().destroy().await.unwrap();
+        nexus_lookup(nexus_name()).unwrap().destroy().await.unwrap();
     });
 
     test_fini();
@@ -105,12 +119,12 @@ fn rebuild_progress() {
 
 #[test]
 fn rebuild_child_faulted() {
-    test_ini();
+    test_ini("rebuild_child_faulted");
 
     Reactor::block_on(async move {
         nexus_create(2).await;
 
-        let nexus = nexus_lookup(NEXUS_NAME).unwrap();
+        let nexus = nexus_lookup(nexus_name()).unwrap();
         nexus
             .start_rebuild(&get_dev(1))
             .expect_err("Rebuild only degraded children!");
@@ -129,14 +143,14 @@ fn rebuild_child_faulted() {
 
 #[test]
 fn rebuild_dst_removal() {
-    test_ini();
+    test_ini("rebuild_dst_removal");
 
     Reactor::block_on(async move {
         let new_child = 2;
         nexus_create(new_child).await;
         nexus_add_child(new_child, false).await;
 
-        let nexus = nexus_lookup(NEXUS_NAME).unwrap();
+        let nexus = nexus_lookup(nexus_name()).unwrap();
         nexus.pause_rebuild(&get_dev(new_child)).await.unwrap();
         nexus.remove_child(&get_dev(new_child)).await.unwrap();
 
@@ -148,7 +162,7 @@ fn rebuild_dst_removal() {
 
 #[test]
 fn rebuild_src_removal() {
-    test_ini();
+    test_ini("rebuild_src_removal");
 
     Reactor::block_on(async move {
         let new_child = 2;
@@ -156,7 +170,7 @@ fn rebuild_src_removal() {
         nexus_create(new_child).await;
         nexus_add_child(new_child, false).await;
 
-        let nexus = nexus_lookup(NEXUS_NAME).unwrap();
+        let nexus = nexus_lookup(nexus_name()).unwrap();
         nexus.pause_rebuild(&get_dev(new_child)).await.unwrap();
         nexus.remove_child(&get_dev(0)).await.unwrap();
 
@@ -171,16 +185,19 @@ fn rebuild_src_removal() {
 }
 
 async fn nexus_create(children: u64) {
+    nexus_create_with_size(NEXUS_SIZE, children).await
+}
+async fn nexus_create_with_size(size: u64, children: u64) {
     let mut ch = Vec::new();
     for i in 0 .. children {
         ch.push(get_dev(i));
     }
 
-    mayastor::bdev::nexus_create(NEXUS_NAME, NEXUS_SIZE, None, &ch)
+    mayastor::bdev::nexus_create(nexus_name(), size, None, &ch)
         .await
         .unwrap();
 
-    let nexus = nexus_lookup(NEXUS_NAME).unwrap();
+    let nexus = nexus_lookup(nexus_name()).unwrap();
     let device = common::device_path_from_uri(
         nexus
             .share(ShareProtocolNexus::NexusNbd, None)
@@ -203,7 +220,7 @@ async fn nexus_create(children: u64) {
 }
 
 async fn nexus_add_child(new_child: u64, wait: bool) {
-    let nexus = nexus_lookup(NEXUS_NAME).unwrap();
+    let nexus = nexus_lookup(nexus_name()).unwrap();
 
     nexus.add_child(&get_dev(new_child), true).await.unwrap();
 
@@ -212,7 +229,8 @@ async fn nexus_add_child(new_child: u64, wait: bool) {
             get_dev(new_child),
             RebuildState::Completed,
             std::time::Duration::from_secs(10),
-        );
+        )
+        .unwrap();
 
         nexus_test_child(new_child).await;
     } else {
@@ -226,15 +244,269 @@ async fn nexus_test_child(child: u64) {
         get_dev(child),
         RebuildState::Completed,
         std::time::Duration::from_secs(10),
-    );
+    )
+    .unwrap();
+
+    let nexus = nexus_lookup(nexus_name()).unwrap();
 
     let (s, r) = unbounded::<String>();
     std::thread::spawn(move || {
         s.send(common::compare_devices(
             &get_disk(0),
             &get_disk(child),
+            nexus.size(),
             true,
         ))
     });
     reactor_poll!(r);
+}
+
+#[test]
+// test rebuild with different combinations of sizes for src and dst children
+fn rebuild_sizes() {
+    test_ini("rebuild_sizes");
+
+    let nexus_size = 10 * 1024 * 1024; // 10MiB
+    let child_size = nexus_size + META_SIZE;
+    let mut test_cases = vec![
+        (nexus_size, child_size, child_size),
+        (nexus_size, child_size * 2, child_size),
+        (nexus_size, child_size, child_size * 2),
+        (nexus_size, child_size * 2, child_size * 2),
+    ];
+    // now for completeness sake we also the cases where the actual
+    // nexus_size will be lower due to the on-disk metadata
+    let child_size = nexus_size;
+    test_cases.extend(vec![
+        (nexus_size, child_size, child_size),
+        (nexus_size, child_size * 2, nexus_size),
+        (nexus_size, child_size, child_size * 2),
+        (nexus_size, child_size * 2, child_size * 2),
+    ]);
+
+    for (test_case_index, test_case) in test_cases.iter().enumerate() {
+        common::delete_file(&[get_disk(0), get_disk(1), get_disk(1)]);
+        // first healthy child in the list is used as the rebuild source
+        common::truncate_file_bytes(&get_disk(0), test_case.1);
+        common::truncate_file_bytes(&get_disk(1), test_case.0);
+        common::truncate_file_bytes(&get_disk(2), test_case.2);
+
+        let nexus_size = test_case.0;
+        Reactor::block_on(async move {
+            // add an extra child so that the minimum size is set to
+            // match the nexus size
+            nexus_create_with_size(nexus_size, 2).await;
+            let nexus = nexus_lookup(nexus_name()).unwrap();
+            nexus.add_child(&get_dev(2), false).await.unwrap();
+            // within start_rebuild the size should be validated
+            let _ = nexus.start_rebuild(&get_dev(2)).unwrap_or_else(|e| {
+                log::error!( "Case {} - Child should have started to rebuild but got error:\n {:}",
+                    test_case_index, e.verbose());
+                panic!(
+                    "Case {} - Child should have started to rebuild but got error:\n {}",
+                    test_case_index, e.verbose()
+                )
+            });
+            // sanity check that the rebuild does succeed
+            nexus_test_child(2).await;
+
+            nexus.destroy().await.unwrap();
+        });
+    }
+
+    test_fini();
+}
+
+#[test]
+// tests the rebuild with multiple size and a non-multiple size of the segment
+fn rebuild_segment_sizes() {
+    test_ini("rebuild_segment_sizes");
+
+    assert!(SEGMENT_SIZE > 512 && SEGMENT_SIZE < NEXUS_SIZE);
+
+    let test_cases = vec![
+        // multiple of SEGMENT_SIZE
+        SEGMENT_SIZE * 10,
+        // not multiple of SEGMENT_SIZE
+        (SEGMENT_SIZE * 10) + 512,
+    ];
+
+    for test_case in test_cases.iter() {
+        let nexus_size = *test_case;
+        Reactor::block_on(async move {
+            nexus_create_with_size(nexus_size, 1).await;
+            nexus_add_child(1, true).await;
+            nexus_lookup(nexus_name()).unwrap().destroy().await.unwrap();
+        });
+    }
+
+    test_fini();
+}
+
+#[test]
+fn rebuild_lookup() {
+    test_ini("rebuild_lookup");
+
+    Reactor::block_on(async move {
+        let children = 6;
+        nexus_create(children).await;
+        let nexus = nexus_lookup(nexus_name()).unwrap();
+        nexus.add_child(&get_dev(children), false).await.unwrap();
+
+        for child in 0 .. children {
+            RebuildJob::lookup(&get_dev(child)).expect_err("Should not exist");
+
+            RebuildJob::lookup_src(&get_dev(child))
+                .iter()
+                .inspect(|&job| {
+                    log::error!(
+                        "Job {:?} should be associated with src child {}",
+                        job,
+                        child
+                    );
+                })
+                .any(|_| panic!("Should not have found any jobs!"));
+        }
+
+        let _ = nexus.start_rebuild(&get_dev(children)).unwrap();
+        for child in 0 .. children - 1 {
+            RebuildJob::lookup(&get_dev(child))
+                .expect_err("rebuild job not created yet");
+        }
+        let src = RebuildJob::lookup(&get_dev(children))
+            .expect("now the job should exist")
+            .source
+            .clone();
+
+        for child in 0 .. children {
+            if get_dev(child) != src {
+                RebuildJob::lookup_src(&get_dev(child))
+                    .iter()
+                    .filter(|s| s.destination != get_dev(child))
+                    .inspect(|&job| {
+                        log::error!(
+                            "Job {:?} should be associated with src child {}",
+                            job,
+                            child
+                        );
+                    })
+                    .any(|_| panic!("Should not have found any jobs!"));
+            }
+        }
+
+        assert_eq!(
+            RebuildJob::lookup_src(&src)
+                .iter()
+                .inspect(|&job| {
+                    assert_eq!(job.destination, get_dev(children));
+                })
+                .count(),
+            1
+        );
+        nexus
+            .add_child(&get_dev(children + 1), false)
+            .await
+            .unwrap();
+        let _ = nexus.start_rebuild(&get_dev(children + 1)).unwrap();
+        assert_eq!(RebuildJob::lookup_src(&src).len(), 2);
+
+        nexus.remove_child(&get_dev(children)).await.unwrap();
+        nexus.remove_child(&get_dev(children + 1)).await.unwrap();
+        nexus_lookup(nexus_name()).unwrap().destroy().await.unwrap();
+    });
+
+    test_fini();
+}
+
+#[test]
+// todo: decide whether to keep the idempotence on the operations or to
+// create a RPC version which achieves the idempotence
+fn rebuild_operations() {
+    test_ini("rebuild_operations");
+
+    Reactor::block_on(async {
+        nexus_create(1).await;
+        let nexus = nexus_lookup(nexus_name()).unwrap();
+
+        nexus
+            .resume_rebuild(&get_dev(1))
+            .await
+            .expect_err("no rebuild to resume");
+
+        nexus_add_child(1, false).await;
+
+        nexus
+            .resume_rebuild(&get_dev(1))
+            .await
+            .expect("already running");
+
+        nexus.pause_rebuild(&get_dev(1)).await.unwrap();
+        reactor_poll!(10);
+        // already pausing so no problem
+        nexus.pause_rebuild(&get_dev(1)).await.unwrap();
+
+        let _ = nexus
+            .start_rebuild(&get_dev(1))
+            .expect_err("a rebuild already exists");
+
+        nexus.stop_rebuild(&get_dev(1)).await.unwrap();
+        common::wait_for_rebuild(
+            get_dev(1),
+            RebuildState::Stopped,
+            // already stopping, should be enough
+            std::time::Duration::from_millis(250),
+        )
+        .unwrap();
+        // already stopped
+        nexus.stop_rebuild(&get_dev(1)).await.unwrap();
+
+        nexus_lookup(nexus_name()).unwrap().destroy().await.unwrap();
+    });
+
+    test_fini();
+}
+
+#[test]
+fn rebuild_concurrently() {
+    test_ini("rebuild_concurrently");
+
+    let concurrent_rebuilds = 4;
+    Reactor::block_on(async move {
+        nexus_create(1).await;
+        let nexus = nexus_lookup(nexus_name()).unwrap();
+
+        for child in 1 ..= concurrent_rebuilds {
+            nexus_add_child(child, false).await;
+        }
+
+        assert_eq!(RebuildJob::count(), concurrent_rebuilds as usize);
+
+        for child in 1 ..= concurrent_rebuilds {
+            common::wait_for_rebuild(
+                get_dev(child),
+                RebuildState::Completed,
+                std::time::Duration::from_secs(10),
+            )
+            .unwrap();
+            nexus.remove_child(&get_dev(child)).await.unwrap();
+        }
+
+        for child in 1 ..= concurrent_rebuilds {
+            nexus_add_child(child, false).await;
+        }
+
+        for child in 1 ..= concurrent_rebuilds {
+            common::wait_for_rebuild(
+                get_dev(child),
+                RebuildState::Running,
+                std::time::Duration::from_millis(100),
+            )
+            .unwrap();
+            nexus.remove_child(&get_dev(child)).await.unwrap();
+        }
+
+        nexus.destroy().await.unwrap();
+    });
+
+    test_fini();
 }

--- a/mayastor/tests/reconfigure.rs
+++ b/mayastor/tests/reconfigure.rs
@@ -177,7 +177,8 @@ async fn works() {
         child2.to_string(),
         RebuildState::Completed,
         std::time::Duration::from_secs(20),
-    );
+    )
+    .unwrap();
 
     assert_eq!(nexus.status(), NexusStatus::Online);
 


### PR DESCRIPTION
added a few more testcases and that led to fixing a few bugs

rebuild with childs of different sizes (prior that would fail) including
using children with sizes < metadata
using non multiple of the segment size for completeness
the lookup of rebuild jobs and concurrent rebuild jobs which revealed a
bug
rebuild operations idempotence (currently on the client api) though we
may want to restrict it to RPC specifically

bonus: when the rebuild tests fail (local or CI) the cargo test itself
gets stuck which is caused by panics on a different thread (?) so moved
the failures to the reactor thread and also use different nexus and bdev
names on each test - this produces a cleaner failure log

rebuild code coverage reported by grcov is now ~84% (if you trust it)

todo: cas-287 will test the IO failures